### PR TITLE
Adds a message properties file. 

### DIFF
--- a/lib/src/main/java/formflow/library/config/LocaleLibraryConfiguration.java
+++ b/lib/src/main/java/formflow/library/config/LocaleLibraryConfiguration.java
@@ -1,0 +1,39 @@
+package formflow.library.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+/**
+ * A locale configuration so that messages can be automatically read from the library and
+ * Spring Boot apps.
+ */
+@Configuration
+public class LocaleLibraryConfiguration {
+  /**
+   * A bean to set message source locations both in this library and in the
+   * default path of Spring Boot apps.
+   *
+   * <p>setBasenames() will do three things:</p>
+   * <ol>
+   *   <li>It will override any previous setting of basenames. Only these names/paths exist now.</li>
+   *   <li>t will look for messages in sequential order and if something is found in a file, it stops looking there.
+   *        Order matters and if you want to provide overrides, make sure they are in the earlier
+   *        files (like 'messages', rather than 'messages-form-flow').</li>
+   *   <li>For i18n this will look for files with the basename + "_[lang]", like messages_en.properties,
+   *        automatically for you.</li>
+   * </ol>
+   *
+   * @return messageSource to be consumed by Spring Boot
+   */
+  @Bean
+  public MessageSource messageSource() {
+    ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+
+    messageSource.setBasenames("messages", "messages-form-flow");
+    messageSource.setDefaultEncoding("UTF-8");
+
+    return messageSource;
+  }
+}

--- a/lib/src/main/resources/messages-form-flow.properties
+++ b/lib/src/main/resources/messages-form-flow.properties
@@ -1,0 +1,16 @@
+general.month=Month
+general.day=Day
+general.year=Year
+general.edit=edit
+general.delete=delete
+general.inputs.yes=Yes
+general.inputs.no=No
+general.inputs.continue=Continue
+general.inputs.submit=Submit
+general.language.english=English
+general.language.spanish=Español
+general.me=Me
+general.you=You
+general.your=Your
+
+error.error=Error


### PR DESCRIPTION
Adds a messages properties file named `messages-form-flow.properties` to this library.  The file name must not conflict with what's in the template starter app, so I gave it this name. 

This pulls in the general properties for the site - though we may want to audit the fragments and pull in any property that's found in those. 