### PR TITLE
WIP: Removes slashes from View's in controller.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -87,7 +87,7 @@ publishing {
             // eventually this should probably be org.codeforamerica.form-flow ...?
             group = "form-flow"
             artifactId = "form-flow-library"
-            version = "0.0.1-SNAPSHOT-TEST"
+            version = "0.0.1-SNAPSHOT"
         }
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -87,7 +87,7 @@ publishing {
             // eventually this should probably be org.codeforamerica.form-flow ...?
             group = "form-flow"
             artifactId = "form-flow-library"
-            version = "0.0-SNAPSHOT"
+            version = "0.0.1-SNAPSHOT-TEST"
         }
     }
 }

--- a/lib/src/main/java/formflow/library/ScreenController.java
+++ b/lib/src/main/java/formflow/library/ScreenController.java
@@ -322,7 +322,7 @@ public class ScreenController {
 			entryToDelete.ifPresent(entry -> httpSession.setAttribute("entryToDelete", entry));
 		}
 
-		return new RedirectView(String.format("/%s/" + deleteConfirmationScreen + "?uuid=" + uuid, flow));
+		return new RedirectView(String.format("%s/" + deleteConfirmationScreen + "?uuid=" + uuid, flow));
 	}
 
 	/**
@@ -406,7 +406,7 @@ public class ScreenController {
 			var entryToEdit = subflowArr.stream()
 					.filter(entry -> entry.get("uuid").equals(uuid)).findFirst();
 			entryToEdit.ifPresent(stringObjectMap -> model.put("inputData", stringObjectMap));
-			model.put("formAction", String.format("/%s/%s/%s/edit", flow, screen, uuid));
+			model.put("formAction", String.format("%s/%s/%s/edit", flow, screen, uuid));
 		} else {
 			return new ModelAndView("error", HttpStatus.BAD_REQUEST);
 		}
@@ -493,7 +493,7 @@ public class ScreenController {
 		String nextScreen = getNextScreenName(httpSession,
 				currentScreen);
 
-		return new RedirectView("/%s/%s".formatted(flow, nextScreen));
+		return new RedirectView("%s/%s".formatted(flow, nextScreen));
 	}
 
 	private String getNextScreenName(HttpSession httpSession,
@@ -588,7 +588,7 @@ public class ScreenController {
 
 	private String createFormActionString(String flow, String screen) {
 		return isIterationStartScreen(flow, screen) ?
-				"/%s/%s/new".formatted(flow, screen) : "/%s/%s".formatted(flow, screen);
+				"%s/%s/new".formatted(flow, screen) : "%s/%s".formatted(flow, screen);
 	}
 
 	private Map<String, Object> createModel(String flow, String screen, HttpSession httpSession, Submission submission) {

--- a/lib/src/main/java/formflow/library/ScreenController.java
+++ b/lib/src/main/java/formflow/library/ScreenController.java
@@ -87,7 +87,7 @@ public class ScreenController {
 				return nothingToDeleteModelAndView;
 			}
 		}
-		return new ModelAndView("/%s/%s".formatted(flow, screen), model);
+		return new ModelAndView("%s/%s".formatted(flow, screen), model);
 	}
 
 	/**
@@ -120,7 +120,7 @@ public class ScreenController {
 		handleErrors(httpSession, errorMessages, formDataSubmission);
 
 		if (errorMessages.size() > 0) {
-			return new ModelAndView(String.format("redirect:/%s/%s", flow, screen));
+			return new ModelAndView(String.format("redirect:%s/%s", flow, screen));
 		}
 
 		// if there's already a session
@@ -134,7 +134,7 @@ public class ScreenController {
 			httpSession.setAttribute("id", submission.getId());
 		}
 
-		return new ModelAndView(String.format("redirect:/%s/%s/navigation", flow, screen));
+		return new ModelAndView(String.format("redirect:%s/%s/navigation", flow, screen));
 	}
 
 	/**
@@ -175,7 +175,7 @@ public class ScreenController {
 		var errorMessages = validationService.validate(flow, formDataSubmission);
 		handleErrors(httpSession, errorMessages, formDataSubmission);
 		if (errorMessages.size() > 0) {
-			return new ModelAndView(String.format("redirect:/%s/%s", flow, screen));
+			return new ModelAndView(String.format("redirect:%s/%s", flow, screen));
 		}
 
 		UUID uuid = UUID.randomUUID();
@@ -200,7 +200,7 @@ public class ScreenController {
 		}
 		String nextScreen = getNextScreenName(httpSession, currentScreen);
 		String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen) ?
-				String.format("redirect:/%s/%s/%s", flow, nextScreen, uuid) : String.format("redirect:/%s/%s", flow, nextScreen);
+				String.format("redirect:%s/%s/%s", flow, nextScreen, uuid) : String.format("redirect:%s/%s", flow, nextScreen);
 		return new ModelAndView(viewString);
 	}
 
@@ -224,8 +224,8 @@ public class ScreenController {
 	) {
 		Submission submission = getSubmission(httpSession);
 		Map<String, Object> model = createModel(flow, screen, httpSession, submission);
-		model.put("formAction", String.format("/%s/%s/%s", flow, screen, uuid));
-		return new ModelAndView(String.format("/%s/%s", flow, screen), model);
+		model.put("formAction", String.format("%s/%s/%s", flow, screen, uuid));
+		return new ModelAndView(String.format("%s/%s", flow, screen), model);
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class ScreenController {
 		var errorMessages = validationService.validate(flow, formDataSubmission);
 		handleErrors(httpSession, errorMessages, formDataSubmission);
 		if (errorMessages.size() > 0) {
-			return new ModelAndView(String.format("redirect:/%s/%s/%s", flow, screen, uuid));
+			return new ModelAndView(String.format("redirect:%s/%s/%s", flow, screen, uuid));
 		}
 
 		if (submissionOptional.isPresent()) {
@@ -282,11 +282,11 @@ public class ScreenController {
 				saveToRepository(updatedSubmission, subflowName);
 			}
 		} else {
-			return new ModelAndView("/error", HttpStatus.BAD_REQUEST);
+			return new ModelAndView("error", HttpStatus.BAD_REQUEST);
 		}
 		String nextScreen = getNextScreenName(httpSession, currentScreen);
 		String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen) ?
-				String.format("redirect:/%s/%s/%s", flow, nextScreen, uuid) : String.format("redirect:/%s/%s", flow, nextScreen);
+				String.format("redirect:%s/%s/%s", flow, nextScreen, uuid) : String.format("redirect:%s/%s", flow, nextScreen);
 		return new ModelAndView(viewString);
 	}
 
@@ -362,17 +362,17 @@ public class ScreenController {
 					existingInputData.remove(subflow);
 					submission.setInputData(existingInputData);
 					saveToRepository(submission, subflow);
-					return new ModelAndView("redirect:/%s/%s".formatted(flow, subflowEntryScreen));
+					return new ModelAndView("redirect:%s/%s".formatted(flow, subflowEntryScreen));
 				}
 			} else {
-				return new ModelAndView("redirect:/%s/%s".formatted(flow, subflowEntryScreen));
+				return new ModelAndView("redirect:%s/%s".formatted(flow, subflowEntryScreen));
 			}
 		} else {
-			return new ModelAndView("/error", HttpStatus.BAD_REQUEST);
+			return new ModelAndView("error", HttpStatus.BAD_REQUEST);
 		}
 		String reviewScreen = getFlowConfigurationByName(flow).getSubflows().get(subflow)
 				.getReviewScreen();
-		return new ModelAndView(String.format("redirect:/%s/" + reviewScreen, flow));
+		return new ModelAndView(String.format("redirect:%s/" + reviewScreen, flow));
 	}
 
 	/**
@@ -408,7 +408,7 @@ public class ScreenController {
 			entryToEdit.ifPresent(stringObjectMap -> model.put("inputData", stringObjectMap));
 			model.put("formAction", String.format("/%s/%s/%s/edit", flow, screen, uuid));
 		} else {
-			return new ModelAndView("/error", HttpStatus.BAD_REQUEST);
+			return new ModelAndView("error", HttpStatus.BAD_REQUEST);
 		}
 
 		return new ModelAndView(String.format("%s/%s", flow, screen), model);
@@ -451,7 +451,7 @@ public class ScreenController {
 		var errorMessages = validationService.validate(flow, formDataSubmission);
 		handleErrors(httpSession, errorMessages, formDataSubmission);
 		if (errorMessages.size() > 0) {
-			return new ModelAndView(String.format("redirect:/%s/%s/%s/edit", flow, screen, uuid));
+			return new ModelAndView(String.format("redirect:%s/%s/%s/edit", flow, screen, uuid));
 		}
 
 		if (submissionOptional.isPresent()) {
@@ -463,11 +463,11 @@ public class ScreenController {
 				saveToRepository(updatedSubmission, subflowName);
 			}
 		} else {
-			return new ModelAndView("/error", HttpStatus.BAD_REQUEST);
+			return new ModelAndView("error", HttpStatus.BAD_REQUEST);
 		}
 		String nextScreen = getNextScreenName(httpSession, currentScreen);
 		String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen) ?
-				String.format("redirect:/%s/%s/%s/edit", flow, nextScreen, uuid) : String.format("redirect:/%s/%s", flow, nextScreen);
+				String.format("redirect:%s/%s/%s/edit", flow, nextScreen, uuid) : String.format("redirect:%s/%s", flow, nextScreen);
 		return new ModelAndView(viewString);
 	}
 
@@ -690,7 +690,7 @@ public class ScreenController {
 				model.put("subflowIsEmpty", true);
 				model.put("entryScreen", getFlowConfigurationByName(flow).getSubflows().get(subflowName).getEntryScreen());
 			}
-			return new ModelAndView("/%s/%s".formatted(flow, screen), model);
+			return new ModelAndView("%s/%s".formatted(flow, screen), model);
 		}
 		return null;
 	}


### PR DESCRIPTION
Also this tweaks the name of the GPR library name, as this is really just a tests. 

This will need more work - it was a quick pass at testing out removing the `/`'s from the paths. It appears to work with a few issues that need to be sorted out. Namely, I get a few pages in (yeah!) and then hit a wonky path it creates, which is probably due to me missing some logic in removing the slashes. Example failing path: `http://localhost:8080/ubi/ubi/languagePreference/navigation`

