### PR TITLE
WIP Adds ability to hide buttons / sign up for dropzone events.

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowDropZone.js
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowDropZone.js
@@ -1,0 +1,19 @@
+FormFlowDZ = {
+  hideContinueIfNoFiles: function (inputName, idToHide) {
+    window[dropzonePrefix + inputName].on('success', function () {
+      $(document.getElementById(idToHide)).removeClass("display-none");
+    });
+
+    window[dropzonePrefix + inputName].on('removedfile', function () {
+      if (window[dropzonePrefix + inputName].files.length === 0) {
+        $(document.getElementById(idToHide)).addClass("display-none");
+      }
+    });
+
+    if (window[dropzonePrefix + inputName].files.length > 0) {
+      $(document.getElementById(idToHide)).removeClass("display-none");
+    }
+  }
+}
+
+window.FormFlowDZ = FormFlowDZ;

--- a/src/main/resources/templates/fragments/fileUploader.html
+++ b/src/main/resources/templates/fragments/fileUploader.html
@@ -55,6 +55,7 @@
   <script src="/webjars/dropzone/5.9.3/dist/min/dropzone.min.js"></script>
   <script th:inline="javascript">
     Dropzone.autoDiscover = false;
+    window.dropzonePrefix = 'myDropZone';
     window['documentIcon'
     + [[${inputName}]]] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABGCAYAAACE0Gk0AAAFK0lEQVR4Xu2caVcTSRSG314SyEJQPIAsMucoihDmzJE1BBhnEZ35xzPjmU9ABAR/AThnFBBQQciedLrn3Epaw6Z9OxsTqr7kQ25XVz31VtWt5baSTiYsyOSIgCJhOeIkjCQs56wkLAYrCasusFKpFF5vbmJ/7x1My4KmqZz3VmRr5A3oHh3DI6Po6e2tKC/Ow67GrJOTE7xaX8PB/gG8Xi8URYFl1XNStZDNZtF+4yamIzO42dHBqbNrWzasbDaDtZUV7GxvIxgMNgAUTUsALCCRSKCzsxMzc3Pw+wOuITh9kA3r9dYmNtZforW1FaqiflEUVaDWqUy8pGbTMpGIx3Fn4DtEorPQdb2mJWDDii0t4mB/Dx6Pt85dj8RkQRGyKiYCZhQMpJJJDN5/gPHJKahq7cZONqznf/6BZCLxuRXtAmfS6RK8WknMgq57hKLLk6KqyGbSSKfTGJuYxPBIuGbqqggWtbRlWtB0HT6fT7RqoVCAUgNeiqLCMPLIZDJFVdkKUyDeSw1Ik8zM7JzolrVIbFh/P/8L8ZMTMXWbBRPpdAq9fX2YikTR0tKCXC5X1lGqV2RN17C3t4dX6y9Fg2iq9iVzhbqkKsrl8/sQnZ1HZ1dX9V5ud3vu2vAsrFQqKVoyOjcvxpBapg8f3mM1FoNhGNC0Mlil8YuUTgN+e/sNROfnxW81U0XKskwTyWRRWSR/j8dTzbKdy+vd7i421tdQMArnYJX6JqhMx8fH6OnpxeyPj8+NcZUUsCqw+vr7EIleAVglheXzOcTjcTwYeojpmWglfE5PJpV0Q1tZVwmWGPxphsxmQDP0D4/GEB79virAmk5ZdncUM2QyiVw2i8npiFBZpak5YRV9C+FSHH/6JFyK+cc/487AQEW8mhdWGbCjw0PhB/70yxN03LrlGlhzwyqNX+TRHH78KECRwtra2lwBa3pYREXViisL6pL9dwYQmYmi1edjA7sWsGxg+XweiXgC94eG8GhsnO0XXhtYtkuRz+VAftjDkTBGwqMXO7eXaO5awRLAFEXAorXkcDjMcimuHSzbDyP/K9TejidPf3M8dv2vYO3u7mBjbRXGZWvDr1T77KYgLcYDwQAWnv3enLBo33/1xTILFjmk1PW8Xg9UVfu8u0uw2kIh/LrwtDlhHR0d4p+tLZimKdZ/ThJt5ZDb8P5gX6wVaaOSNg6bHlY5HKdHb+JgwyxgeXFRnEgFAn4Bms4em1pZTpR0kQ2paCW2jO23b8SRGTmpEtYlNMkZXYktYWd7RyrrW4qTsL5FqOx/CUvCYhBgmEplSVgMAgxTqSwJi0GAYSqVJWExCDBMpbIkLAYBhqlUloTFIMAwlcqSsBgEGKZSWRIWgwDDVCpLwmIQYJhKZUlYDAIMU6ksCYtBgGF6pZRVrwgLBp9TpgTrxfISdncaeMhKgU71jN1xC4vuRVCc5Ns3/zbu+L6eUWFuQFHgK8VwUzz12kpMKMvn89fvrkN5cGY94w1dwbIg7ozSFSUK3iwYBhSVLhwVrxwFgkEsPKvhzb/GRbK6wUXPFC+z0VVuXdNPXWarOaxGxki7xXX2OfsSblf3bREn6TSx75Q2NPreaa0usitF7ttR+xQ+PD4xibv3Bh3nyoZ1Jb7r4Lh6pw3tj3XQ9yD6+vsxFYmgpeV0gPrXsmbDoswa/8UQPi0bFMVwd3V3YWxiCqFQiJWRK1j0hkZ+i4ZVw5JxoWBCVRR03+7B3cFB+P1+djauYbHf1AQPSFiMRpSwJCwGAYbpf7oLq5uJEmkZAAAAAElFTkSuQmCC";
     window['isUploadComplete' + [[${inputName}]]] = true;
@@ -120,7 +121,7 @@
 
     function destroyerCreator(file) {
       return function () {
-        window['myDropZone' + [[${inputName}]]].emit('addFileToBeDestroyed', file);
+        window[dropzonePrefix + [[${inputName}]]].emit('addFileToBeDestroyed', file);
       }
     }
 
@@ -131,16 +132,16 @@
     }
 
     function processDZQueueAfterThumbnailGeneration() {
-      var allUploadsHaveThumbnails = window['myDropZone'
-      + [[${inputName}]]].getQueuedFiles().every(
-          f => f.dataURL && f.dataURL.length > 0);
+      var allUploadsHaveThumbnails = window[dropzonePrefix + [[${inputName}]]]
+      .getQueuedFiles()
+      .every(f => f.dataURL && f.dataURL.length > 0);
       if (allUploadsHaveThumbnails) {
-        window['myDropZone' + [[${inputName}]]].processQueue();
+        window[dropzonePrefix + [[${inputName}]]].processQueue();
       }
     }
 
     function showNumberOfAddedFiles() {
-      var numberOfAddedFiles = window['myDropZone' + [[${inputName}]]].files.length;
+      var numberOfAddedFiles = window[dropzonePrefix + [[${inputName}]]].files.length;
       var numberOfAddedFilesDiv = document.getElementById(
           "number-of-uploaded-files-" + [[${inputName}]]);
       var numberOfUploadsString = numberOfAddedFiles !== 1 ? `${numberOfAddedFiles} files added`
@@ -150,7 +151,7 @@
 
     function setDefaultThumbnail(file) {
       file.dataURL = window['documentIcon' + [[${inputName}]]];
-      window['myDropZone' + [[${inputName}]]].emit("thumbnail", file,
+      window[dropzonePrefix + [[${inputName}]]].emit("thumbnail", file,
           window['documentIcon' + [[${inputName}]]]);
     }
 
@@ -189,7 +190,7 @@
     }
 
     function removeFileFromDropzone(file, id) {
-      window['myDropZone' + [[${inputName}]]].removeFile(file);
+      window[dropzonePrefix + [[${inputName}]]].removeFile(file);
       if (id) {
         let toDeleteIdx = window['userFileIds' + [[${inputName}]]].indexOf(id);
         if (toDeleteIdx !== -1) {
@@ -271,7 +272,7 @@
               <p class='text--error spacing-above-0' aria-live="assertive" aria-atomic="true"></p>
             </div>`,
       init: function () {
-        window['myDropZone' + [[${inputName}]]] = this;
+        window[dropzonePrefix + [[${inputName}]]] = this;
         var dzInstance = [[${inputName}]]
         var documents = userFiles !== null ? userFiles[dzInstance] : [];
 
@@ -280,8 +281,8 @@
         }
 
         this.on('addedfile', function (file) {
-          if (window['myDropZone' + [[${inputName}]]].files.length > window['myDropZone'
-          + [[${inputName}]]].options.maxFiles) {
+          if (window[dropzonePrefix + [[${inputName}]]].files.length
+              >= window[dropzonePrefix + [[${inputName}]]].options.maxFiles) {
             toggleMaxFileMessage('on');
           }
           var fileNameSpan = file.previewElement.getElementsByClassName('filename-text')[0];
@@ -397,12 +398,12 @@
               id: parseInt(uploadedDocWithThumbnail[0]),
               accepted: true
             };
-            window['myDropZone' + [[${inputName}]]].files.push(mockFile);
-            window['myDropZone' + [[${inputName}]]].emit("addedfile", mockFile);
-            window['myDropZone' + [[${inputName}]]].emit("thumbnail", mockFile,
+            window[dropzonePrefix + [[${inputName}]]].files.push(mockFile);
+            window[dropzonePrefix + [[${inputName}]]].emit("addedfile", mockFile);
+            window[dropzonePrefix + [[${inputName}]]].emit("thumbnail", mockFile,
                 doc.thumbnailUrl);
-            window['myDropZone' + [[${inputName}]]].emit("success", mockFile, mockFile.id);
-            window['myDropZone' + [[${inputName}]]].emit("complete", mockFile);
+            window[dropzonePrefix + [[${inputName}]]].emit("success", mockFile, mockFile.id);
+            window[dropzonePrefix + [[${inputName}]]].emit("complete", mockFile);
           });
         }
       },
@@ -413,20 +414,20 @@
           var message = errorMessage.error ? errorMessage.error : errorMessage;
           // special case error message for unsupported HEIC file type uploads
           if (message.localeCompare(
-                  window['myDropZone' + [[${inputName}]]].options.dictInvalidFileType) == 0
+                  window[dropzonePrefix + [[${inputName}]]].options.dictInvalidFileType) == 0
               && file.name.toLocaleLowerCase().endsWith('.heic')) {
             message = window['heicFilesNotAccepted' + [[${inputName}]]];
           }
           file.previewElement.getElementsByClassName("text--error")[0].innerText = message;
         }
 
-        for (var i = 0; i < window['myDropZone' + [[${inputName}]]].files.length; i++) {
-          if (window['myDropZone' + [[${inputName}]]].files[i] === file) {
-            window['myDropZone' + [[${inputName}]]].files.splice(i, 1);
+        for (var i = 0; i < window[dropzonePrefix + [[${inputName}]]].files.length; i++) {
+          if (window[dropzonePrefix + [[${inputName}]]].files[i] === file) {
+            window[dropzonePrefix + [[${inputName}]]].files.splice(i, 1);
           }
         }
 
-        if (window['myDropZone' + [[${inputName}]]].files.length === 0) {
+        if (window[dropzonePrefix + [[${inputName}]]].files.length === 0) {
           $('#submit-my-documents-' + [[${inputName}]]).addClass('hidden');
         }
 

--- a/src/main/resources/templates/fragments/libraryHead.html
+++ b/src/main/resources/templates/fragments/libraryHead.html
@@ -15,5 +15,6 @@
         crossorigin="anonymous"/>
   <link rel="preload" href="/webjars/form-flow/0.0.1/js/honeycrisp.min.js" as="script">
   <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
+  <script src="/webjars/form-flow/0.0.1/js/formFlowDropZone.js"></script>
 </th:block>
 </html>


### PR DESCRIPTION
finishes: https://www.pivotaltracker.com/story/show/182837559
Co-Authored-By: Ben Calegari; bcalegari@codeforamerica.org

Adds ability for starter app templates to "register" for some behavior on a dropzone widget. 
Namely, this adds a new form flow JS file geared towards adding a way SNE users can interact with dropzone.  We opted to do this to fulfill the desire to maybe hide the "continue" button on the file upload page. A SNE can choose to hide the button or not now, depending on if they use the function in the new JS file.  This keeps the system flexible and encapsulated. 



