### PR TITLE
Protect input names with inherited class from library

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ extend the class `FlowInputs` which provides CSRF functionality for security.
 Also note that for single value inputs the type when defining the input is String. However, for
 input types that can contain more than one value, the type is ArrayList<String>.
 
-When naming your inputs in your templates, make sure that you use camel case so that the given input
-name can also be used as a field name in your inputs class.
+When naming your inputs in your templates, **you must use camel case so that the given input
+name can also be used as a field name in your inputs class**. Java will require that to be the case.
 
 ```java
 class ApplicationInformation extends FlowInputs {

--- a/README.md
+++ b/README.md
@@ -321,13 +321,18 @@ The library will expect a class that matches the name of the flow there. So if t
 defined in the application's `flows-config.yaml` configuration, is `ubi` we will expect a class by
 the name of `Ubi` to be located at the specified input path.
 
-An example inputs class can be seen below, with example validations.
+An example inputs class can be seen below, with example validations. Note that all inputs classses
+should
+extend the class `FlowInputs` which provides CSRF functionality for security.
 
-Please note that for single value inputs the type when defining the input is String. However, for
+Also note that for single value inputs the type when defining the input is String. However, for
 input types that can contain more than one value, the type is ArrayList<String>.
 
+When naming your inputs in your templates, make sure that you use camel case so that the given input
+name can also be used as a field name in your inputs class.
+
 ```java
-class ApplicationInformation {
+class ApplicationInformation extends FlowInputs {
 
   @NotBlank(message = "{personal-info.provide-first-name}")
   String firstName;

--- a/src/main/java/formflow/library/data/FlowInputs.java
+++ b/src/main/java/formflow/library/data/FlowInputs.java
@@ -1,0 +1,9 @@
+package formflow.library.data;
+
+import javax.validation.constraints.NotBlank;
+
+public class FlowInputs {
+
+  @NotBlank
+  private String _csrf;
+}

--- a/src/test/java/formflow/library/inputs/TestFlow.java
+++ b/src/test/java/formflow/library/inputs/TestFlow.java
@@ -1,8 +1,8 @@
 package formflow.library.inputs;
 
+import formflow.library.data.FlowInputs;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Transient;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
@@ -11,11 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @TestConfiguration
 @SuppressWarnings("unused")
-public class TestFlow {
-
-  // Ignore csrf for validation
-  @Transient
-  String _csrf;
+public class TestFlow extends FlowInputs {
 
   @NotBlank(message = "{validations.make-sure-to-provide-a-first-name}")
   String firstName;

--- a/src/test/java/formflow/library/inputs/UploadFlow.java
+++ b/src/test/java/formflow/library/inputs/UploadFlow.java
@@ -1,13 +1,10 @@
 package formflow.library.inputs;
 
-import javax.persistence.Transient;
+import formflow.library.data.FlowInputs;
 import org.springframework.boot.test.context.TestConfiguration;
 
 @TestConfiguration
-public class UploadFlow {
+public class UploadFlow extends FlowInputs {
 
-  // Ignore csrf for validation
-  @Transient
-  String _csrf;
   String uploadTest;
 }

--- a/src/test/java/formflow/library/upload/UploadJourneyTests.java
+++ b/src/test/java/formflow/library/upload/UploadJourneyTests.java
@@ -28,35 +28,35 @@ public class UploadJourneyTests extends AbstractBasePageTest {
 
     // Test accepted file types
     // Extension list comes from application.yaml -- form-flow.uploads.accepted-file-types
-    uploadFile("test.tif", "doc-upload-files");
+    uploadFile("test.tif", "uploadTest");
     Assertions.assertThat(testPage.findElementsByClass("text--error").get(0).getText())
         .isEqualTo(
             "We aren't able to upload this type of file. Please try another file that ends in one of the following: .jpeg, .fake");
     testPage.clickLink("remove");
-    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-doc-upload-files")).isEqualTo("0 files added");
+    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-uploadTest")).isEqualTo("0 files added");
     // Upload a file that is too big and assert the correct error shows - max file size in test is 1MB
     long largeFilesize = 21000000L;
     driver.executeScript(
-        "$('#document-upload-doc-upload-files').get(0).dropzone.addFile({name: 'testFile.pdf', size: "
+        "$('#document-upload-uploadTest').get(0).dropzone.addFile({name: 'testFile.pdf', size: "
             + largeFilesize + ", type: 'not-an-image'})");
     int maxFileSize = 17;
     Assertions.assertThat(driver.findElement(By.className("text--error")).getText()).contains(
         "This file is too large and cannot be uploaded (max size: " + maxFileSize + " MB)");
     testPage.clickLink("remove");
-    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-doc-upload-files")).isEqualTo("0 files added");
-    uploadJpgFile("doc-upload-files");
-    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-doc-upload-files")).isEqualTo("1 file added");
-    uploadJpgFile("doc-upload-files"); // 2
-    uploadJpgFile("doc-upload-files"); // 3
-    uploadJpgFile("doc-upload-files"); // 4
-    uploadJpgFile("doc-upload-files"); // 5
-    uploadJpgFile("doc-upload-files"); // Can't upload the 6th
+    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-uploadTest")).isEqualTo("0 files added");
+    uploadJpgFile("uploadTest");
+    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-uploadTest")).isEqualTo("1 file added");
+    uploadJpgFile("uploadTest"); // 2
+    uploadJpgFile("uploadTest"); // 3
+    uploadJpgFile("uploadTest"); // 4
+    uploadJpgFile("uploadTest"); // 5
+    uploadJpgFile("uploadTest"); // Can't upload the 6th
     Assertions.assertThat(testPage.findElementsByClass("text--error").get(0).getText())
         .isEqualTo(
             "You have uploaded the maximum number of files. You will have the opportunity to share more with a caseworker later.");
     testPage.clickLink("remove");
     // Assert there are no longer any error after removing the errored item
-    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-doc-upload-files")).isEqualTo("5 files added");
+    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-uploadTest")).isEqualTo("5 files added");
     Assertions.assertThat(
             testPage.findElementsByClass("text--error").stream().map(WebElement::getText).collect(Collectors.toList()))
         .allMatch(String::isEmpty);
@@ -66,6 +66,6 @@ public class UploadJourneyTests extends AbstractBasePageTest {
       driver.switchTo().alert().accept();
     }
     Assertions.assertThat(testPage.findElementsByClass("dz-remove").size()).isEqualTo(0);
-    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-doc-upload-files")).isEqualTo("0 files added");
+    Assertions.assertThat(testPage.findElementTextById("number-of-uploaded-files-uploadTest")).isEqualTo("0 files added");
   }
 }

--- a/src/test/resources/templates/uploadFlow/docUploadJourney.html
+++ b/src/test/resources/templates/uploadFlow/docUploadJourney.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
 <head th:replace="fragments/head :: head(title='Upload Documents')"></head>
-<body>
+<body th:with="dzFormName='uploadTest'">
 <div class="page-wrapper" id="uploadTest">
   <div th:replace="fragments/toolbar :: toolbar"></div>
   <section class="slab">
     <div class="grid">
       <div th:replace="fragments/goBack :: goBackLink"></div>
-      <main id="content" role="main" class="form-card spacing-above-35"
-            th:with="dzFormName='uploadTest'">
+      <main id="content" role="main" class="form-card spacing-above-35">
         <th:block
             th:replace="'fragments/cardHeader' :: cardHeader(header='Upload Documents')"/>
         <th:block
@@ -29,7 +28,7 @@
   </section>
 </div>
 <script>
-  FormFlowDZ.hideContinueIfNoFiles('uploadTest', 'submit');
+  FormFlowDZ.hideContinueIfNoFiles('[[${dzFormName}]]', 'submit');
 </script>
 </body>
 </html>

--- a/src/test/resources/templates/uploadFlow/docUploadJourney.html
+++ b/src/test/resources/templates/uploadFlow/docUploadJourney.html
@@ -8,7 +8,7 @@
     <div class="grid">
       <div th:replace="fragments/goBack :: goBackLink"></div>
       <main id="content" role="main" class="form-card spacing-above-35"
-            th:with="dzFormName='doc-upload-files'">
+            th:with="dzFormName='uploadTest'">
         <th:block
             th:replace="'fragments/cardHeader' :: cardHeader(header='Upload Documents')"/>
         <th:block
@@ -29,7 +29,7 @@
   </section>
 </div>
 <script>
-  FormFlowDZ.hideContinueIfNoFiles([[${inputName}]], 'submit');
+  FormFlowDZ.hideContinueIfNoFiles('uploadTest', 'submit');
 </script>
 </body>
 </html>

--- a/src/test/resources/templates/uploadFlow/docUploadUnit.html
+++ b/src/test/resources/templates/uploadFlow/docUploadUnit.html
@@ -4,7 +4,8 @@
 <script src="https://code.jquery.com/qunit/qunit-2.19.3.js"></script>
 <script src="/webjars/form-flow/0.0.1/js/qunit-upload-tests.js"></script>
 <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.3.css">
-<body>
+<body
+    th:with="dzFormName='uploadTest'">
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
 <div class="page-wrapper" id="uploadTest">
@@ -12,8 +13,7 @@
   <section class="slab">
     <div class="grid">
       <div th:replace="fragments/goBack :: goBackLink"></div>
-      <main id="content" role="main" class="form-card spacing-above-35"
-            th:with="dzFormName='uploadTest'">
+      <main id="content" role="main" class="form-card spacing-above-35">
         <th:block
             th:replace="'fragments/cardHeader' :: cardHeader(header='Upload Test')"/>
         <th:block
@@ -34,7 +34,7 @@
   </section>
 </div>
 <script>
-  FormFlowDZ.hideContinueIfNoFiles('uploadTest', 'submit');
+  FormFlowDZ.hideContinueIfNoFiles('[[${dzFormName}]]', 'submit');
 </script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a class `FlowInputs` which all flow input classes will inherit from. Example `public class Ubi extends FlowInputs`. 

The parent class now holds the _csrf token field.

Having all flow inputs classes extend this class will also enforce that input fields are always declared in a corresponding flow inputs class that extends the FlowInputs class. 

One unintended but seemingly unavoidable change this PR introduces, is the need to camel case input names so that they can be used as fields in a flow inputs class (i.e. a field name cannot be `doc-upload-files` it has to be `docUploadFiles`). 