### PR TITLE
Generic error page

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,21 @@ The template HTML can look like:
 
 The IntelliJ Live Template for the above example can be generated with `cfa:staticPage`.
 
+#### Error Page
+
+A generic error page is provided by the library in place of a white label page. In order to see the
+error page you will need to add the following to your application's `application.yaml` file:
+
+```yaml
+server:
+  error:
+    whitelabel:
+      enabled: false
+```
+
+You can also override our error page by placing your own `error.html` file in your application's
+templates folder.
+
 ### Fragments
 
 #### Form

--- a/src/main/resources/messages-form-flow.properties
+++ b/src/main/resources/messages-form-flow.properties
@@ -21,4 +21,6 @@ general.files.add-your-files=Add your files
 upload-documents.this-file-is-too-large=This file is too large and cannot be uploaded (max size: {0} MB)
 #
 error.error=Error
+error.uh-oh=Uh oh!
+error.its-not-you-description=We're sorry, but something went wrong. Please try again later.
 error.files.invalid-file-type=We aren't able to upload this type of file. Please try another file that ends in one of the following:

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="fragments/head :: head(title=#{error.error})"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="fragments/toolbar :: toolbar"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="fragments/goBack :: goBackLink"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="'fragments/icons' :: error"></th:block>
+        <th:block
+            th:replace="'fragments/cardHeader' :: cardHeader(header=#{error.uh-oh}, subtext=#{error.its-not-you-description})"/>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="fragments/footer :: footer"/>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a generic error page to the library. SNE's can override this generic error page by placing their own `error.html` file in their applications templates folder.

SNE's will need to add:

```
server:
  error:
    whitelabel:
      enabled: false
```
To their applications `application.yaml` in order to see or override the error page. 