### PR TITLE
Remove console log on dropzone success

### DIFF
--- a/src/main/resources/templates/fragments/fileUploader.html
+++ b/src/main/resources/templates/fragments/fileUploader.html
@@ -342,7 +342,6 @@
         });
 
         this.on('success', function (file, id, e) {
-          console.log("error is " + e);
           var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];
           var thumbnail = file.previewElement.getElementsByClassName("dz-thumb")[0];
           var progressBar = file.previewElement.getElementsByClassName("dz-progress")[0];


### PR DESCRIPTION
Small clean up, we probably don't want to be posting to the console when a file is successful. I think we had it in there for debugging purposes.