### PR TITLE
Add submit/continue buttons to templates

### DIFF
--- a/intellij-settings/LiveTemplates.xml
+++ b/intellij-settings/LiveTemplates.xml
@@ -42,18 +42,18 @@
   <option name="HTML" value="true" />
 </context>
 </template>
-<template name="cfa:form" value="&lt;th:block th:replace=&quot;'fragments/form' :: form(action=${formAction}, content=~{::$FORM_CONTENT$})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;$FORM_CONTENT$&quot;&gt;&#10;    &lt;div class=&quot;form-card__content&quot;&gt;&#10;      $CARD_CONTENT$&#10;    &lt;/div&gt;&#10;    &lt;div class=&quot;form-card__footer&quot;&gt;&#10;      $CARD_FOOTER$&#10;    &lt;/div&gt;&#10;  &lt;/th:block&gt;&#10; &lt;/th:block&gt;" description="A form with an action and custom content" toReformat="false" toShortenFQNames="true">
+<template name="cfa:form" value="&lt;th:block th:replace=&quot;'fragments/form' :: form(action=${formAction}, content=~{::$FORM_CONTENT$})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;$FORM_CONTENT$&quot;&gt;&#10;    &lt;div class=&quot;form-card__content&quot;&gt;&#10;      $CARD_CONTENT$&#10;    &lt;/div&gt;&#10;    &lt;div class=&quot;form-card__footer&quot;&gt;&#10;      &lt;th:block th:replace=&quot;fragments/inputs/submitButton :: submitButton(&#10;        text=#{general.inputs.continue})&quot;/&gt;&#10;    &lt;/div&gt;&#10;  &lt;/th:block&gt;&#10; &lt;/th:block&gt;" description="A form with an action and custom content" toReformat="false" toShortenFQNames="true">
 <variable name="FORM_CONTENT" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="CARD_CONTENT" expression="" defaultValue="" alwaysStopAt="true" />
-<variable name="CARD_FOOTER" expression="" defaultValue="" alwaysStopAt="true" />
 <context>
   <option name="HTML" value="true" />
 </context>
 </template>
-<template name="cfa:formlessScreen" value="&lt;!DOCTYPE html&gt;&#10;&lt;html th:lang=&quot;${#locale.language}&quot;&gt;&#10;&lt;head th:replace=&quot;fragments/head :: head(title=#{$SCREEN_TITLE$})&quot;&gt;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;div class=&quot;page-wrapper&quot;&gt;&#10;  &lt;div th:replace=&quot;fragments/toolbar :: toolbar&quot;&gt;&lt;/div&gt;&#10;  &lt;section class=&quot;slab&quot;&gt;&#10;    &lt;div class=&quot;grid&quot;&gt;&#10;      &lt;div th:replace=&quot;fragments/goBack :: goBackLink&quot;&gt;&lt;/div&gt;&#10;      &lt;main id=&quot;content&quot; role=&quot;main&quot; class=&quot;form-card spacing-above-35&quot;&gt;&#10;        &lt;th:block&#10;            th:replace=&quot;'fragments/cardHeader' :: cardHeader(header=#{$SCREEN_HEADER$}, subtext=#{$OPTIONAL_SUB_HEADER$})&quot;/&gt;&#10;        &lt;div class=&quot;form-card__content&quot;&gt;&#10;&#10;        &lt;/div&gt;&#10;        &lt;div class=&quot;form-card__footer&quot;&gt;&#10;              &#10;        &lt;/div&gt;&#10;      &lt;/main&gt;&#10;    &lt;/div&gt;&#10;  &lt;/section&gt;&#10;&lt;/div&gt;&#10;&lt;th:block th:replace=&quot;fragments/footer :: footer&quot;/&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;" description="A card screen page with no form" toReformat="false" toShortenFQNames="true">
+<template name="cfa:formlessScreen" value="&lt;!DOCTYPE html&gt;&#10;&lt;html th:lang=&quot;${#locale.language}&quot;&gt;&#10;&lt;head th:replace=&quot;fragments/head :: head(title=#{$SCREEN_TITLE$})&quot;&gt;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;div class=&quot;page-wrapper&quot;&gt;&#10;  &lt;div th:replace=&quot;fragments/toolbar :: toolbar&quot;&gt;&lt;/div&gt;&#10;  &lt;section class=&quot;slab&quot;&gt;&#10;    &lt;div class=&quot;grid&quot;&gt;&#10;      &lt;div th:replace=&quot;fragments/goBack :: goBackLink&quot;&gt;&lt;/div&gt;&#10;      &lt;main id=&quot;content&quot; role=&quot;main&quot; class=&quot;form-card spacing-above-35&quot;&gt;&#10;        &lt;th:block&#10;            th:replace=&quot;'fragments/cardHeader' :: cardHeader(header=#{$SCREEN_HEADER$}, subtext=#{$OPTIONAL_SUB_HEADER$})&quot;/&gt;&#10;        &lt;div class=&quot;form-card__content&quot;&gt;&#10;          $FORM_CONTENT$&#10;        &lt;/div&gt;&#10;        &lt;div class=&quot;form-card__footer&quot;&gt;&#10;          &lt;th:block th:replace=&quot;'fragments/continueButton' :: continue&quot;/&gt;&#10;        &lt;/div&gt;&#10;      &lt;/main&gt;&#10;    &lt;/div&gt;&#10;  &lt;/section&gt;&#10;&lt;/div&gt;&#10;&lt;th:block th:replace=&quot;fragments/footer :: footer&quot;/&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;" description="A card screen page with no form" toReformat="false" toShortenFQNames="true">
 <variable name="SCREEN_TITLE" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="SCREEN_HEADER" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="OPTIONAL_SUB_HEADER" expression="" defaultValue="" alwaysStopAt="true" />
+<variable name="FORM_CONTENT" expression="" defaultValue="" alwaysStopAt="true" />
 <context>
   <option name="HTML" value="true" />
 </context>
@@ -197,12 +197,6 @@
   <option name="HTML" value="true" />
 </context>
 </template>
-<variable name="INPUT_NAME" expression="" defaultValue="" alwaysStopAt="true" />
-<variable name="HELP_TEXT" expression="" defaultValue="" alwaysStopAt="true" />
-<context>
-  <option name="HTML" value="true" />
-</context>
-</template>
 <template name="cfa:reveal" value="&lt;th:block th:replace=&quot;'fragments/honeycrisp/reveal' :: reveal(&#10;  linkLabel=~{::$LINK_LABEL$})&quot;&gt;&#10;  content=~{::$CONTENT_REF$})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;$CONTENT_REF$&quot;&gt;&#10;     $REVEAL_CONTENT$&#10;    &lt;/th:block&gt;&#10;&lt;/th:block&gt;" description="A honeycrisp reveal with linkLabel and custom content" toReformat="false" toShortenFQNames="true">
 <variable name="LINK_LABEL" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="CONTENT_REF" expression="" defaultValue="" alwaysStopAt="true" />
@@ -211,13 +205,12 @@
   <option name="HTML" value="true" />
 </context>
 </template>
-<template name="cfa:screen" value="&lt;!DOCTYPE html&gt;&#10;&lt;html th:lang=&quot;${#locale.language}&quot;&gt;&#10;&lt;head th:replace=&quot;fragments/head :: head(title=#{$TITLE$})&quot;&gt;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;div class=&quot;page-wrapper&quot;&gt;&#10;  &lt;div th:replace=&quot;fragments/toolbar :: toolbar&quot;&gt;&lt;/div&gt;&#10;  &lt;section class=&quot;slab&quot;&gt;&#10;    &lt;div class=&quot;grid&quot;&gt;&#10;      &lt;div th:replace=&quot;fragments/goBack :: goBackLink&quot;&gt;&lt;/div&gt;&#10;      &lt;main id=&quot;content&quot; role=&quot;main&quot; class=&quot;form-card spacing-above-35&quot;&gt;&#10;        &lt;th:block&#10;            th:replace=&quot;'fragments/cardHeader' :: cardHeader(header=#{$CARD_HEADER$}, subtext=#{$CARD_SUBTEXT$})&quot;/&gt;&#10;          &lt;th:block th:replace=&quot;'fragments/form' :: form(action=${formAction}, content=~{::$FORM_CONTENT$})&quot;&gt;&#10;            &lt;th:block th:ref=&quot;$FORM_CONTENT$&quot;&gt;&#10;              &lt;div class=&quot;form-card__content&quot;&gt;&#10;                $CARD_CONTENT$&#10;              &lt;/div&gt;&#10;            &lt;div class=&quot;form-card__footer&quot;&gt;&#10;              $CARD_FOOTER$&#10;            &lt;/div&gt;&#10;          &lt;/th:block&gt;&#10;        &lt;/th:block&gt;&#10;      &lt;/main&gt;&#10;    &lt;/div&gt;&#10;  &lt;/section&gt;&#10;&lt;/div&gt;&#10;&lt;th:block th:replace=&quot;fragments/footer :: footer&quot; /&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;&#10;" description="Insert an entire screen template" toReformat="false" toShortenFQNames="true">
+<template name="cfa:screen" value="&lt;!DOCTYPE html&gt;&#10;&lt;html th:lang=&quot;${#locale.language}&quot;&gt;&#10;&lt;head th:replace=&quot;fragments/head :: head(title=#{$TITLE$})&quot;&gt;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;div class=&quot;page-wrapper&quot;&gt;&#10;  &lt;div th:replace=&quot;fragments/toolbar :: toolbar&quot;&gt;&lt;/div&gt;&#10;  &lt;section class=&quot;slab&quot;&gt;&#10;    &lt;div class=&quot;grid&quot;&gt;&#10;      &lt;div th:replace=&quot;fragments/goBack :: goBackLink&quot;&gt;&lt;/div&gt;&#10;      &lt;main id=&quot;content&quot; role=&quot;main&quot; class=&quot;form-card spacing-above-35&quot;&gt;&#10;        &lt;th:block&#10;            th:replace=&quot;'fragments/cardHeader' :: cardHeader(header=#{$CARD_HEADER$}, subtext=#{$CARD_SUBTEXT$})&quot;/&gt;&#10;          &lt;th:block th:replace=&quot;'fragments/form' :: form(action=${formAction}, content=~{::$FORM_CONTENT$})&quot;&gt;&#10;            &lt;th:block th:ref=&quot;$FORM_CONTENT$&quot;&gt;&#10;              &lt;div class=&quot;form-card__content&quot;&gt;&#10;                $CARD_CONTENT$&#10;              &lt;/div&gt;&#10;            &lt;div class=&quot;form-card__footer&quot;&gt;&#10;              &lt;th:block th:replace=&quot;fragments/inputs/submitButton :: submitButton(&#10;                  text=#{general.inputs.continue})&quot;/&gt;&#10;            &lt;/div&gt;&#10;          &lt;/th:block&gt;&#10;        &lt;/th:block&gt;&#10;      &lt;/main&gt;&#10;    &lt;/div&gt;&#10;  &lt;/section&gt;&#10;&lt;/div&gt;&#10;&lt;th:block th:replace=&quot;fragments/footer :: footer&quot; /&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;&#10;" description="Insert an entire screen template" toReformat="false" toShortenFQNames="true">
 <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="CARD_HEADER" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="CARD_SUBTEXT" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="FORM_CONTENT" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="CARD_CONTENT" expression="" defaultValue="" alwaysStopAt="true" />
-<variable name="CARD_FOOTER" expression="" defaultValue="" alwaysStopAt="true" />
 <context>
   <option name="HTML" value="true" />
 </context>


### PR DESCRIPTION
- `cfa:form` now has submit
- `cfa:formlessScreen` now has continue
- remove empty template that causes paste to fail (same as [this PR](https://github.com/codeforamerica/form-flow/pull/128))
- `cfa:screen` now has submit