### PR TITLE
Using 'disabled' property

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowDropZone.js
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowDropZone.js
@@ -14,20 +14,20 @@ FormFlowDZ = {
       $(document.getElementById(idToHide)).removeClass("display-none");
     }
   },
-    disableIfNoFiles: function (inputName, idToDisable) {
-      window[dropzonePrefix + inputName].on('success', function () {
-        $(document.getElementById(idToDisable)).removeClass("disabled");
-      });
+  disableIfNoFiles: function (inputName, idToDisable) {
+    window[dropzonePrefix + inputName].on('success', function () {
+      $(document.getElementById(idToDisable)).prop( "disabled", false );
+    });
 
-      window[dropzonePrefix + inputName].on('removedfile', function () {
-        if (window[dropzonePrefix + inputName].files.length === 0) {
-          $(document.getElementById(idToDisable)).addClass("disabled");
-        }
-      });
-
-      if (window[dropzonePrefix + inputName].files.length > 0) {
-        $(document.getElementById(idToDisable)).removeClass("disabled");
+    window[dropzonePrefix + inputName].on('removedfile', function () {
+      if (window[dropzonePrefix + inputName].files.length === 0) {
+        $(document.getElementById(idToDisable)).prop( "disabled", true );
       }
+    });
+
+    if (window[dropzonePrefix + inputName].files.length > 0) {
+      $(document.getElementById(idToDisable)).prop( "disabled", false );
+    }
   }
 }
 


### PR DESCRIPTION
I _think_ this is more accessible than class name

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled

Elements with the `disabled` attribute are skipped over by screen readers. I think the class itself is not enough indication for other readers to identify it as "disabled"