### PR TITLE
Adding id to continue button link

### DIFF
--- a/src/main/resources/templates/fragments/continueButton.html
+++ b/src/main/resources/templates/fragments/continueButton.html
@@ -1,4 +1,5 @@
 <a th:fragment="continue"
    th:href="'/' + ${flow} + '/' + ${screen} + '/navigation'"
    th:text="${text} ? ${text} : #{general.inputs.continue}"
-   class="button button--primary"></a>
+   class="button button--primary"
+   id="continue-link"></a>


### PR DESCRIPTION
Adding id to continue button link for easier selection and tracking.

Button/Link text can change based on locale - `id` can be used to track it across locales