### PR TITLE
App correctly fails to start w/o flows-config file

### DIFF
--- a/src/main/java/formflow/library/config/FlowsConfigurationFactory.java
+++ b/src/main/java/formflow/library/config/FlowsConfigurationFactory.java
@@ -1,28 +1,29 @@
 package formflow.library.config;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
-import org.springframework.beans.factory.annotation.Value;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Parses the flow configuration yaml file and setups the FlowConfiguration list.
  */
+@Slf4j
 public class FlowsConfigurationFactory implements FactoryBean<List<FlowConfiguration>> {
 
   @Value("${form-flow.path:flows-config.yaml}")
   String configPath;
 
   @Override
-  public List<FlowConfiguration> getObject() {
+  public List<FlowConfiguration> getObject() throws IOException {
     ClassPathResource classPathResource = new ClassPathResource(configPath);
 
     LoaderOptions loaderOptions = new LoaderOptions();
@@ -35,11 +36,10 @@ public class FlowsConfigurationFactory implements FactoryBean<List<FlowConfigura
     List<FlowConfiguration> appConfigs = new ArrayList<>();
     try {
       Iterable<Object> appConfigsIterable = yaml.loadAll(classPathResource.getInputStream());
-      appConfigsIterable.forEach(appConfig -> {
-        appConfigs.add((FlowConfiguration) appConfig);
-      });
+      appConfigsIterable.forEach(appConfig -> appConfigs.add((FlowConfiguration) appConfig));
     } catch (IOException e) {
-      e.printStackTrace();
+      log.error("Can't find the flow configuration file: " + configPath, e);
+      throw e;
     }
 
     return appConfigs;

--- a/src/main/java/formflow/library/config/FlowsConfigurationFactoryConfig.java
+++ b/src/main/java/formflow/library/config/FlowsConfigurationFactoryConfig.java
@@ -1,5 +1,6 @@
 package formflow.library.config;
 
+import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,7 +28,7 @@ public class FlowsConfigurationFactoryConfig {
    * @return list of flow configuration objects
    */
   @Bean
-  public List<FlowConfiguration> flowsConfiguration() {
+  public List<FlowConfiguration> flowsConfiguration() throws IOException {
     return flowsConfigurationFactory().getObject();
   }
 }

--- a/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
+++ b/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
@@ -48,7 +48,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = MOCK)
+@SpringBootTest(webEnvironment = MOCK, properties = {"form-flow.path=/flows-config/test-flow.yaml"})
 @AutoConfigureMockMvc
 @ContextConfiguration
 public abstract class AbstractMockMvcTest {

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,5 +1,5 @@
 form-flow:
-  path: 'flows-config.yaml'
+  path: 'test-flow.yaml'
   inputs: 'formflow.library.inputs.'
   uploads:
     accepted-file-types: '.jpeg, .fake, .heic, .tif, .tiff, .pdf'


### PR DESCRIPTION
- Tests that start spring now use test-flows.yaml by default

Co-authored-by: Alex Gonzalez <agonzalez@codeforamerica.org>