### PR TITLE
Add "iconName" option to screen fragments

### DIFF
--- a/intellij-settings/LiveTemplates.xml
+++ b/intellij-settings/LiveTemplates.xml
@@ -238,19 +238,21 @@
   <option name="HTML" value="true" />
 </context>
 </template>
-<template name="cfa:screenWithOneInput" value="&lt;th:block&#10;  th:replace=&quot;fragments/screens/screenWithOneInput ::&#10;  screenWithOneInput(&#10;    title=#{$TITLE$},&#10;    header=#{$HEADER$},&#10;    subtext=#{$SUBTEXT$},&#10;    formAction=${formAction},&#10;    inputContent=~{::inputContent})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;inputContent&quot;&gt;&#10;    &lt;!-- Be sure to have `ariaLabel='header'` to label the input with the header --&gt;&#10;    &lt;th:block th:replace=&quot;'fragments/inputs/text' ::&#10;      text(inputName='$INPUT_NAME$',&#10;      ariaLabel='header')&quot;/&gt;&#10;  &lt;/th:block&gt;&#10;&lt;/th:block&gt;" description="An entire screen that has one input and is labelled by the page header." toReformat="false" toShortenFQNames="true">
+<template name="cfa:screenWithOneInput" value="&lt;th:block&#10;  th:replace=&quot;fragments/screens/screenWithOneInput ::&#10;  screenWithOneInput(&#10;    title=#{$TITLE$},&#10;    header=#{$HEADER$},&#10;    subtext=#{$SUBTEXT$},&#10;    iconName=#{$ICON$},&#10;    formAction=${formAction},&#10;    inputContent=~{::inputContent})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;inputContent&quot;&gt;&#10;    &lt;!-- Be sure to have `ariaLabel='header'` to label the input with the header --&gt;&#10;    &lt;th:block th:replace=&quot;'fragments/inputs/text' ::&#10;      text(inputName='$INPUT_NAME$',&#10;      ariaLabel='header')&quot;/&gt;&#10;  &lt;/th:block&gt;&#10;&lt;/th:block&gt;" description="An entire screen that has one input and is labelled by the page header." toReformat="false" toShortenFQNames="true">
 <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="HEADER" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="SUBTEXT" expression="" defaultValue="" alwaysStopAt="true" />
+<variable name="ICON" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="INPUT_NAME" expression="" defaultValue="" alwaysStopAt="true" />
 <context>
   <option name="HTML" value="true" />
 </context>
 </template>
-<template name="cfa:screenWithYesAndNoButtons" value="&lt;th:block&#10;  th:replace=&quot;fragments/screens/screenWithYesAndNoButtons ::&#10;  screenWithYesAndNoButtons(&#10;    title=#{$TITLE$},&#10;    header=#{$HEADER$},&#10;    subtext=#{$SUBTEXT$},&#10;    formAction=${formAction},&#10;    inputName=${inputName},&#10;    inputContent=~{::inputContent})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;inputContent&quot;&gt;&#10;    &lt;!-- Be sure to have `ariaLabel='header'` to label the input with the header --&gt;&#10;  &lt;/th:block&gt;&#10;&lt;/th:block&gt;" description="An entire screen that has two buttons ('Yes' and 'No') and is labelled by the page header." toReformat="false" toShortenFQNames="true">
+<template name="cfa:screenWithYesAndNoButtons" value="&lt;th:block&#10;  th:replace=&quot;fragments/screens/screenWithYesAndNoButtons ::&#10;  screenWithYesAndNoButtons(&#10;    title=#{$TITLE$},&#10;    header=#{$HEADER$},&#10;    subtext=#{$SUBTEXT$},&#10;    iconName=#{$ICON$},&#10;    formAction=${formAction},&#10;    inputName=${inputName},&#10;    inputContent=~{::inputContent})&quot;&gt;&#10;  &lt;th:block th:ref=&quot;inputContent&quot;&gt;&#10;    &lt;!-- Be sure to have `ariaLabel='header'` to label the input with the header --&gt;&#10;  &lt;/th:block&gt;&#10;&lt;/th:block&gt;" description="An entire screen that has two buttons ('Yes' and 'No') and is labelled by the page header." toReformat="false" toShortenFQNames="true">
 <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="HEADER" expression="" defaultValue="" alwaysStopAt="true" />
 <variable name="SUBTEXT" expression="" defaultValue="" alwaysStopAt="true" />
+<variable name="ICON" expression="" defaultValue="" alwaysStopAt="true" />
 <context>
   <option name="HTML" value="true" />
 </context>

--- a/src/main/resources/templates/fragments/screens/screenWithOneInput.html
+++ b/src/main/resources/templates/fragments/screens/screenWithOneInput.html
@@ -1,5 +1,7 @@
 <th:block
     th:fragment="screenWithOneInput"
+    th:with="
+      hasIconName=${!#strings.isEmpty(iconName)}"
     th:assert="
       ${!#strings.isEmpty(title)},
       ${!#strings.isEmpty(header)},
@@ -15,6 +17,7 @@
       <div class="grid">
         <div th:replace="fragments/goBack :: goBackLink"></div>
         <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="${hasIconName} ? ~{'fragments/icons' :: ${iconName}} : _" />
           <th:block
               th:replace="'fragments/cardHeader' :: cardHeader(header=${header}, subtext=${subtext})"/>
           <th:block

--- a/src/main/resources/templates/fragments/screens/screenWithYesAndNoButtons.html
+++ b/src/main/resources/templates/fragments/screens/screenWithYesAndNoButtons.html
@@ -2,7 +2,8 @@
     th:fragment="screenWithYesAndNoButtons"
     th:with="
       hasHelpText=${!#strings.isEmpty(helpText)},
-      hasAriaDescribe=${!#strings.isEmpty(ariaDescribe)}"
+      hasAriaDescribe=${!#strings.isEmpty(ariaDescribe)},
+      hasIconName=${!#strings.isEmpty(iconName)}"
     th:assert="
       ${!#strings.isEmpty(title)},
       ${!#strings.isEmpty(header)},
@@ -19,6 +20,7 @@
       <div class="grid">
         <div th:replace="fragments/goBack :: goBackLink"></div>
         <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="${hasIconName} ? ~{'fragments/icons' :: ${iconName}} : _" />
           <th:block
               th:replace="'fragments/cardHeader' :: cardHeader(header=${header})"/>
           <th:block


### PR DESCRIPTION
These screen fragments are nice, but they lack a key feature: an icon!

This commit simply adds an (optional) iconName argument to add an icon into the header.