### PR TITLE
Add `currentSubflowItem` to get attributes of the current item

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ the database. It is stored in a column named `inputData` on the `submissions` ta
 * The input fields on pages that are not part of a subflow will be stored in the main part of the
   JSON data. The keys will be the input fields name.
 * The input fields that are part of a subflow will be stored in an array under a key that is the
-  name of the subflow.
+  name of the subflow. To access the current item on a subflow page, use `currentSubflowItem`.
 * Field names are used as keys. We use them directly as they are and therefore they must be unique
   across a whole flow to avoid naming collisions. The example applies a prefix to the fields, but
   that's just for ease of being clear in the example. The system does not apply prefixes.

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -282,6 +282,8 @@ public class ScreenController extends FormFlowController {
     var currentScreen = getScreenConfig(flow, screen);
     actionManager.handleBeforeDisplayAction(currentScreen, submission, uuid);
     Map<String, Object> model = createModel(flow, screen, httpSession, submission);
+    var currentObject = submission.getSubflowEntryByUuid(currentScreen.getSubflow(), uuid);
+    model.put("currentSubflowItem", currentObject);
     model.put("formAction", String.format("/flow/%s/%s/%s", flow, screen, uuid));
     return new ModelAndView(String.format("%s/%s", flow, screen), model);
   }

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -19,11 +19,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest(properties = {"form-flow.path=flows-config/test-flow.yaml"})
 public class ScreenControllerTest extends AbstractMockMvcTest {
@@ -54,6 +56,19 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       queryParams.put("lang", "en");
       getWithQueryParam("test", "lang", "en");
       assert(submission.getUrlParams().equals(queryParams));
+    }
+  }
+
+  @Nested
+  public class SubflowParameters {
+    @Test
+    public void modelIncludesCurrentSubflowItem() throws Exception {
+      HashMap<String, String> subflowItem = new HashMap<>();
+      subflowItem.put("uuid", "aaa-bbb-ccc");
+      subflowItem.put("firstName", "foo bar baz");
+
+      submission.setInputData(Map.of("testSubflow", List.of(subflowItem)));
+      getPageExpectingSuccess("subflowAddItem/aaa-bbb-ccc");
     }
   }
 

--- a/src/test/resources/flows-config/test-flow.yaml
+++ b/src/test/resources/flows-config/test-flow.yaml
@@ -18,6 +18,10 @@ flow:
   testAddressVerification:
     nextScreens:
       - name: test
+  subflowAddItem:
+    subflow: testSubflow
+    nextScreens:
+      - name: test
   test:
     nextScreens:
       - name: success

--- a/src/test/resources/templates/testFlow/subflowAddItem.html
+++ b/src/test/resources/templates/testFlow/subflowAddItem.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title='Subflow Page')}"></head>
+<body >
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block
+            th:replace="~{fragments/cardHeader :: cardHeader(header='Subflow Page', subtext='This is a page within a subflow')}"/>
+            <!-- Test that the currentSubflowItem is passed in by the controller: -->
+            <div th:text="${currentSubflowItem.firstName}"></div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/continueButton :: continue}" />
+            </div>
+          </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}" />
+</body>
+</html>


### PR DESCRIPTION
This allows pages within a subflow to get attributes that were previously submitted onto the current subflow item.