### PR TITLE
Add `noneOfTheAbove` boolean to `checkboxInSet` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,10 +996,16 @@ Below are examples of both types of checkboxes:
 
 Note that the `checkboxInSet` fragment is used to provide multiple options within
 a `checkboxFieldset` fragment. Also note that the input name fo the `checkboxFieldset` and
-the `checkboxInSet`
-are the same. This is how the fieldset and internal checkbox options are grouped into a single
-multiple checkbox
-input.
+the `checkboxInSet` are the same. This is how the fieldset and internal checkbox options are grouped
+into a single multiple checkbox input.
+
+To support a "None of the Above" checkbox, add `noneOfTheAbove=true` to the arguments to `checkboxInSet()`:
+```html
+<th:block
+    th:replace="'fragments/inputs/checkboxInSet' :: checkboxInSet(inputName='vehiclesOwned',value='None of the Above', label='None of the Above', noneOfTheAbove=true)"/>
+```
+Honeycrisp contains JavaScript logic that deselects the other checkboxes when "None of the Above" is selected. To enable it, you'll need to add `noneOfTheAbove.init()` to your JavaScript that runs after page load.
+
 
 #### Checkbox
 

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -7,16 +7,17 @@
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
-      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(inputData.getOrDefault(name, ''), value)}"
+      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(inputData.getOrDefault(name, ''), value)},
+      id=${#bools.isTrue(noneOfTheAbove) ? 'none__checkbox' : inputName + '-' + value}"
     th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-  <label th:for="${inputName} + '-' + ${value}"
-         th:id="${inputName} + '-' + ${value} + '-label'"
+  <label th:for="${id}"
+         th:id="${id} + '-label'"
          class="checkbox display-flex">
     <input type="checkbox"
-           th:id="${inputName} + '-' + ${value}"
+           th:id="${id}"
            th:value="${value}"
            th:name="${name}"
            th:checked="${checked}"
@@ -29,7 +30,7 @@
     <div>
       <span th:text="${label}"></span>
       <p th:if="${hasHelpText}"
-         th:id="${inputName} + '-' + ${value} + '-help-text'"
+         th:id="${id} + '-help-text'"
          th:text="${checkboxHelpText}"
          class="text--help with-no-padding"></p>
     </div>


### PR DESCRIPTION
In order to create a checkbox list where the last item is "None of the Above", this commit allows users of the library to pass `noneOfTheAbove=true` for the last checkbox. (Note that the honeycrisp JS will also need to be enabled with `noneOfTheAbove.init()`.)