### PR TITLE
Overwrite default field preparers with application specific custom ones

### DIFF
--- a/src/main/java/formflow/library/pdf/CheckboxField.java
+++ b/src/main/java/formflow/library/pdf/CheckboxField.java
@@ -1,7 +1,19 @@
 package formflow.library.pdf;
 
 import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
-public record CheckboxField(String name, List<String> value, Integer iteration) implements SubmissionField {
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class CheckboxField extends SubmissionField {
 
+  List<String> value;
+  Integer iteration;
+
+  public CheckboxField(String name, List<String> value, Integer iteration) {
+    super(name);
+    this.value = value;
+    this.iteration = iteration;
+  }
 }

--- a/src/main/java/formflow/library/pdf/DataBaseFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/DataBaseFieldPreparer.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class DataBaseFieldPreparer implements SubmissionFieldPreparer {
+public class DataBaseFieldPreparer implements DefaultSubmissionFieldPreparer {
 
   private final PdfMapConfiguration pdfMapConfiguration;
 

--- a/src/main/java/formflow/library/pdf/DataBaseFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/DataBaseFieldPreparer.java
@@ -2,10 +2,8 @@ package formflow.library.pdf;
 
 import formflow.library.data.Submission;
 import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -22,17 +20,17 @@ public class DataBaseFieldPreparer implements DefaultSubmissionFieldPreparer {
   }
 
   @Override
-  public List<SubmissionField> prepareSubmissionFields(Submission submission) {
-    List<SubmissionField> databaseFields = new ArrayList<>();
+  public Map<String, SubmissionField> prepareSubmissionFields(Submission submission) {
+    Map<String, SubmissionField> databaseFields = new HashMap<>();
     Map<String, Object> dbFields = pdfMapConfiguration.getPdfMap(submission.getFlow()).getDbFields();
 
     dbFields.forEach((fieldName, value) -> {
       switch (fieldName) {
-        case "submittedAt" -> databaseFields.add(new DatabaseField(fieldName, formatDateWithNoTime(submission.getSubmittedAt())));
-        case "submissionId" -> databaseFields.add(new DatabaseField(fieldName, submission.getId().toString()));
-        case "createdAt" -> databaseFields.add(new DatabaseField(fieldName, formatDateWithNoTime(submission.getCreatedAt())));
-        case "updatedAt" -> databaseFields.add(new DatabaseField(fieldName, formatDateWithNoTime(submission.getUpdatedAt())));
-        case "flow" -> databaseFields.add(new DatabaseField(fieldName, submission.getFlow()));
+        case "submittedAt" -> databaseFields.put(fieldName, new DatabaseField(fieldName, formatDateWithNoTime(submission.getSubmittedAt())));
+        case "submissionId" -> databaseFields.put(fieldName, new DatabaseField(fieldName, submission.getId().toString()));
+        case "createdAt" -> databaseFields.put(fieldName, new DatabaseField(fieldName, formatDateWithNoTime(submission.getCreatedAt())));
+        case "updatedAt" -> databaseFields.put(fieldName, new DatabaseField(fieldName, formatDateWithNoTime(submission.getUpdatedAt())));
+        case "flow" -> databaseFields.put(fieldName, new DatabaseField(fieldName, submission.getFlow()));
         default -> log.error("Unable to map unknown database field: {}", fieldName);
       }
     });

--- a/src/main/java/formflow/library/pdf/DatabaseField.java
+++ b/src/main/java/formflow/library/pdf/DatabaseField.java
@@ -1,7 +1,18 @@
 package formflow.library.pdf;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 
-public record DatabaseField(String name, @NotNull String value) implements SubmissionField {
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class DatabaseField extends SubmissionField {
+
+  @NotNull String value;
+
+  public DatabaseField(String name, @NotNull String value) {
+    super(name);
+    this.value = value;
+  }
 
 }

--- a/src/main/java/formflow/library/pdf/DefaultSubmissionFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/DefaultSubmissionFieldPreparer.java
@@ -1,0 +1,9 @@
+package formflow.library.pdf;
+
+import formflow.library.data.Submission;
+import java.util.List;
+
+public interface DefaultSubmissionFieldPreparer {
+
+  List<SubmissionField> prepareSubmissionFields(Submission submission);
+}

--- a/src/main/java/formflow/library/pdf/DefaultSubmissionFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/DefaultSubmissionFieldPreparer.java
@@ -1,9 +1,9 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
-import java.util.List;
+import java.util.Map;
 
 public interface DefaultSubmissionFieldPreparer {
 
-  List<SubmissionField> prepareSubmissionFields(Submission submission);
+  Map<String, SubmissionField> prepareSubmissionFields(Submission submission);
 }

--- a/src/main/java/formflow/library/pdf/OneToManyPreparer.java
+++ b/src/main/java/formflow/library/pdf/OneToManyPreparer.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OneToManyPreparer implements SubmissionFieldPreparer {
+public class OneToManyPreparer implements DefaultSubmissionFieldPreparer {
 
   private final PdfMapConfiguration pdfMapConfiguration;
 

--- a/src/main/java/formflow/library/pdf/OneToManyPreparer.java
+++ b/src/main/java/formflow/library/pdf/OneToManyPreparer.java
@@ -1,9 +1,9 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,16 +16,20 @@ public class OneToManyPreparer implements DefaultSubmissionFieldPreparer {
   }
 
   @Override
-  public List<SubmissionField> prepareSubmissionFields(Submission submission) {
+  public Map<String, SubmissionField> prepareSubmissionFields(Submission submission) {
     Map<String, Object> fieldMap = pdfMapConfiguration.getPdfMap(submission.getFlow()).getInputFields();
-    return fieldMap.keySet().stream()
+    Map<String, SubmissionField> preppedFields = new HashMap<>();
+
+    fieldMap.keySet().stream()
         .filter(field -> fieldMap.get(field) instanceof Map && submission.getInputData().get(field + "[]") != null)
-        .map(
-            field -> new CheckboxField(
-                field,
-                (List<String>) submission.getInputData().get(field + "[]"),
-                null
-            ))
-        .collect(Collectors.toList());
+        .forEach(field ->
+            preppedFields.put(field, new CheckboxField(
+                    field,
+                    (List<String>) submission.getInputData().get(field + "[]"),
+                    null
+                )
+            )
+        );
+    return preppedFields;
   }
 }

--- a/src/main/java/formflow/library/pdf/OneToOnePreparer.java
+++ b/src/main/java/formflow/library/pdf/OneToOnePreparer.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OneToOnePreparer implements SubmissionFieldPreparer {
+public class OneToOnePreparer implements DefaultSubmissionFieldPreparer {
 
   private final PdfMapConfiguration pdfMapConfiguration;
 

--- a/src/main/java/formflow/library/pdf/OneToOnePreparer.java
+++ b/src/main/java/formflow/library/pdf/OneToOnePreparer.java
@@ -1,9 +1,8 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,16 +15,20 @@ public class OneToOnePreparer implements DefaultSubmissionFieldPreparer {
   }
 
   @Override
-  public List<SubmissionField> prepareSubmissionFields(Submission submission) {
+  public Map<String, SubmissionField> prepareSubmissionFields(Submission submission) {
     Map<String, Object> fieldMap = pdfMapConfiguration.getPdfMap(submission.getFlow()).getInputFields();
-    return fieldMap.keySet().stream()
+    Map<String, SubmissionField> preppedFields = new HashMap<>();
+    fieldMap.keySet().stream()
         .filter(field -> (fieldMap.get(field) instanceof String) && (submission.getInputData().get(field) != null))
-        .map(field -> new SingleField(
-                field,
-                submission.getInputData().get(field).toString(),
-                null
+        .forEach(field ->
+            preppedFields.put(field, new SingleField(
+                    field,
+                    submission.getInputData().get(field).toString(),
+                    null
+                )
             )
-        )
-        .collect(Collectors.toList());
+        );
+
+    return preppedFields;
   }
 }

--- a/src/main/java/formflow/library/pdf/PdfFieldMapper.java
+++ b/src/main/java/formflow/library/pdf/PdfFieldMapper.java
@@ -34,24 +34,24 @@ public class PdfFieldMapper {
   @NotNull
   private PdfField mapDatabaseFieldFromFlow(DatabaseField input, String flow) {
     Map<String, Object> pdfDbMapForFlow = getPdfDbMapForFlow(flow);
-    String pdfFieldName = pdfDbMapForFlow.get(input.name()).toString();
-    return new PdfField(pdfFieldName, input.value());
+    String pdfFieldName = pdfDbMapForFlow.get(input.getName()).toString();
+    return new PdfField(pdfFieldName, input.getValue());
   }
 
   @NotNull
   private PdfField mapSingleFieldFromFlow(SingleField input, String flow) {
     Map<String, Object> pdfInputsMap = getPdfInputMapForFlow(flow);
-    String pdfFieldName = pdfInputsMap.get(input.name()).toString();
-    return new PdfField(pdfFieldName, input.value());
+    String pdfFieldName = pdfInputsMap.get(input.getName()).toString();
+    return new PdfField(pdfFieldName, input.getValue());
   }
 
   @NotNull
   private List<PdfField> mapMultiValueFieldFromFlow(CheckboxField input, String flow) {
     Map<String, Object> pdfInputsMap = getPdfInputMapForFlow(flow);
 
-    Map<String, String> pdfFieldMap = (Map<String, String>) pdfInputsMap.get(input.name());
+    Map<String, String> pdfFieldMap = (Map<String, String>) pdfInputsMap.get(input.getName());
 
-    return input.value().stream()
+    return input.getValue().stream()
         .map(value -> new PdfField(pdfFieldMap.get(value), "Yes"))
         .collect(Collectors.toList());
   }

--- a/src/main/java/formflow/library/pdf/SingleField.java
+++ b/src/main/java/formflow/library/pdf/SingleField.java
@@ -1,7 +1,20 @@
 package formflow.library.pdf;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 
-public record SingleField(String name, @NotNull String value, Integer iteration) implements
-    SubmissionField {
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class SingleField extends SubmissionField {
+
+  @NotNull String value;
+  Integer iteration;
+
+  public SingleField(String name, @NotNull String value, Integer iteration) {
+    super(name);
+    this.value = value;
+    this.iteration = iteration;
+  }
 }
+

--- a/src/main/java/formflow/library/pdf/SubmissionField.java
+++ b/src/main/java/formflow/library/pdf/SubmissionField.java
@@ -1,9 +1,20 @@
 package formflow.library.pdf;
 
-public interface SubmissionField {
-  Integer iteration = null;
+public abstract class SubmissionField {
 
-  default String getNameWithIteration(String name) {
+  public Integer iteration = null;
+
+  public String name = null;
+
+  SubmissionField(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getNameWithIteration(String name) {
     return iteration != null ? name + "_" + iteration : name;
   }
 }

--- a/src/main/java/formflow/library/pdf/SubmissionFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/SubmissionFieldPreparer.java
@@ -1,9 +1,9 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
-import java.util.List;
+import java.util.Map;
 
 public interface SubmissionFieldPreparer {
 
-  List<SubmissionField> prepareSubmissionFields(Submission submission);
+  Map<String, SubmissionField> prepareSubmissionFields(Submission submission);
 }

--- a/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
+++ b/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
@@ -1,7 +1,7 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,11 +22,11 @@ public class SubmissionFieldPreparers {
 
   public List<SubmissionField> prepareSubmissionFields(Submission submission) {
 
-    List<SubmissionField> fields = new ArrayList<>();
+    HashMap<String, SubmissionField> submissionFieldsMap = new HashMap<>();
 
     defaultPreparers.forEach(preparer -> {
       try {
-        fields.addAll(preparer.prepareSubmissionFields(submission));
+        submissionFieldsMap.putAll(preparer.prepareSubmissionFields(submission));
       } catch (Exception e) {
         String preparerClassName = preparer.getClass().getSimpleName();
         log.error("There was an issue preparing submission data for " + preparerClassName, e);
@@ -35,12 +35,13 @@ public class SubmissionFieldPreparers {
 
     customPreparers.forEach(preparer -> {
       try {
-        fields.addAll(preparer.prepareSubmissionFields(submission));
+        submissionFieldsMap.putAll(preparer.prepareSubmissionFields(submission));
       } catch (Exception e) {
         String preparerClassName = preparer.getClass().getSimpleName();
         log.error("There was an issue preparing submission data for " + preparerClassName, e);
       }
     });
-    return fields;
+
+    return submissionFieldsMap.values().stream().toList();
   }
 }

--- a/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
+++ b/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
@@ -10,19 +10,30 @@ import org.springframework.stereotype.Component;
 @Component
 public class SubmissionFieldPreparers {
 
-  private final List<SubmissionFieldPreparer> preparers;
+  private final List<DefaultSubmissionFieldPreparer> defaultPreparers;
 
-  public SubmissionFieldPreparers(List<SubmissionFieldPreparer> preparers) {
-    this.preparers = preparers;
+  private final List<SubmissionFieldPreparer> customPreparers;
+
+  public SubmissionFieldPreparers(List<DefaultSubmissionFieldPreparer> defaultPreparers,
+      List<SubmissionFieldPreparer> customPreparers) {
+    this.defaultPreparers = defaultPreparers;
+    this.customPreparers = customPreparers;
   }
 
   public List<SubmissionField> prepareSubmissionFields(Submission submission) {
 
-    // Add default fields
     List<SubmissionField> fields = new ArrayList<>();
 
-    // Run all the preparers
-    preparers.forEach(preparer -> {
+    defaultPreparers.forEach(preparer -> {
+      try {
+        fields.addAll(preparer.prepareSubmissionFields(submission));
+      } catch (Exception e) {
+        String preparerClassName = preparer.getClass().getSimpleName();
+        log.error("There was an issue preparing submission data for " + preparerClassName, e);
+      }
+    });
+
+    customPreparers.forEach(preparer -> {
       try {
         fields.addAll(preparer.prepareSubmissionFields(submission));
       } catch (Exception e) {

--- a/src/test/java/formflow/library/pdf/DatabaseFieldPreparerTest.java
+++ b/src/test/java/formflow/library/pdf/DatabaseFieldPreparerTest.java
@@ -37,23 +37,23 @@ class DatabaseFieldPreparerTest {
   @Test
   void prepareReturnsDatabaseFieldsSubmittedAtDate() {
     DataBaseFieldPreparer dataBaseFieldPreparer = new DataBaseFieldPreparer(pdfMapConfiguration);
-    assertThat(dataBaseFieldPreparer.prepareSubmissionFields(submission)).contains(
-        new DatabaseField("submittedAt", "09/15/2020")
+    assertThat(dataBaseFieldPreparer.prepareSubmissionFields(submission)).containsEntry(
+        "submittedAt", new DatabaseField("submittedAt", "09/15/2020")
     );
   }
 
   @Test
   void shouldNotCreateDbFieldsForItemsNotPresentInPdfMap() {
     DataBaseFieldPreparer dataBaseFieldPreparer = new DataBaseFieldPreparer(pdfMapConfiguration);
-    assertThat(dataBaseFieldPreparer.prepareSubmissionFields(submission)).containsExactlyInAnyOrder(
-        new DatabaseField("flow", submission.getFlow()),
-        new DatabaseField("submittedAt", "09/15/2020"),
-        new DatabaseField("createdAt", "09/14/2020")
+    assertThat(dataBaseFieldPreparer.prepareSubmissionFields(submission)).containsAllEntriesOf(
+        Map.of("flow", new DatabaseField("flow", submission.getFlow()),
+            "submittedAt", new DatabaseField("submittedAt", "09/15/2020"),
+            "createdAt", new DatabaseField("createdAt", "09/14/2020"))
     );
 
     assertThat(dataBaseFieldPreparer.prepareSubmissionFields(submission)).doesNotContain(
-        new DatabaseField("submissionId", submission.getId().toString()),
-        new DatabaseField("updatedAt", "09/15/2020")
+        Map.entry("submissionId", new DatabaseField("submissionId", submission.getId().toString())),
+        Map.entry("updatedAt", new DatabaseField("updatedAt", "09/15/2020"))
     );
   }
 }

--- a/src/test/java/formflow/library/pdf/OneToManyPreparerTest.java
+++ b/src/test/java/formflow/library/pdf/OneToManyPreparerTest.java
@@ -33,9 +33,8 @@ class OneToManyPreparerTest {
     ));
     OneToManyPreparer oneToManyPreparer = new OneToManyPreparer(new PdfMapConfiguration(List.of(map)));
 
-    assertThat(oneToManyPreparer.prepareSubmissionFields(submission)).containsExactlyInAnyOrder(
-        new CheckboxField("checkbox", List.of("option1", "option3"), null)
+    assertThat(oneToManyPreparer.prepareSubmissionFields(submission)).containsExactly(
+        Map.entry("checkbox", new CheckboxField("checkbox", List.of("option1", "option3"), null))
     );
   }
-
 }

--- a/src/test/java/formflow/library/pdf/OneToOnePreparerTest.java
+++ b/src/test/java/formflow/library/pdf/OneToOnePreparerTest.java
@@ -32,9 +32,9 @@ class OneToOnePreparerTest {
     ));
     OneToOnePreparer oneToOnePreparer = new OneToOnePreparer(new PdfMapConfiguration(List.of(map)));
 
-    assertThat(oneToOnePreparer.prepareSubmissionFields(submission)).containsExactlyInAnyOrder(
-        new SingleField("inputName1", "foo", null),
-        new SingleField("inputName2", "bar", null)
+    assertThat(oneToOnePreparer.prepareSubmissionFields(submission)).containsExactly(
+        Map.entry("inputName1", new SingleField("inputName1", "foo", null)),
+        Map.entry("inputName2", new SingleField("inputName2", "bar", null))
     );
   }
 
@@ -52,7 +52,7 @@ class OneToOnePreparerTest {
     OneToOnePreparer oneToOnePreparer = new OneToOnePreparer(new PdfMapConfiguration(List.of(map)));
 
     assertThat(oneToOnePreparer.prepareSubmissionFields(submission)).containsExactly(
-        new SingleField("inputName1", "foo", null)
+        Map.entry("inputName1", new SingleField("inputName1", "foo", null))
     );
   }
 }

--- a/src/test/java/formflow/library/pdf/PdfGeneratorTest.java
+++ b/src/test/java/formflow/library/pdf/PdfGeneratorTest.java
@@ -64,5 +64,4 @@ class PdfGeneratorTest extends PdfTest {
     assertPdfFieldEquals("CHECKBOX_OPTION_2", "Off");
     assertPdfFieldEquals("CHECKBOX_OPTION_3", checkboxOptionValue);
   }
-
 }

--- a/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
 
 class SingleFieldPreparersTest {
 
-  private SubmissionFieldPreparers preparers;
-
   private Submission testSubmission;
 
   @BeforeEach
@@ -30,10 +28,10 @@ class SingleFieldPreparersTest {
 
   @Test
   void shouldStillSuccessfullyMapEvenWithExceptionsInIndividualPreparers() {
-    SubmissionFieldPreparer successfulPreparer = mock(SubmissionFieldPreparer.class);
-    SubmissionFieldPreparer failingPreparer = mock(SubmissionFieldPreparer.class);
+    DefaultSubmissionFieldPreparer successfulPreparer = mock(DefaultSubmissionFieldPreparer.class);
+    DefaultSubmissionFieldPreparer failingPreparer = mock(DefaultSubmissionFieldPreparer.class);
     SubmissionFieldPreparers submissionFieldPreparers = new SubmissionFieldPreparers(
-        List.of(failingPreparer, successfulPreparer));
+        List.of(failingPreparer, successfulPreparer), List.of());
     Date date = DateTime.parse("2020-09-02").toDate();
 
     List<SubmissionField> mockOutput = List.of(

--- a/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import formflow.library.data.Submission;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,11 +35,10 @@ class SingleFieldPreparersTest {
         List.of(failingPreparer, successfulPreparer), List.of());
     Date date = DateTime.parse("2020-09-02").toDate();
 
-    List<SubmissionField> mockOutput = List.of(
-        new DatabaseField("submittedAt", String.valueOf(date))
+    Map<String, SubmissionField> mockOutput = Map.of(
+        "submittedAt", new DatabaseField("submittedAt", String.valueOf(date))
     );
-    when(successfulPreparer.prepareSubmissionFields(eq(testSubmission)))
-        .thenReturn(mockOutput);
+    when(successfulPreparer.prepareSubmissionFields(eq(testSubmission))).thenReturn(mockOutput);
     when(failingPreparer.prepareSubmissionFields(eq(testSubmission)))
         .thenThrow(IllegalArgumentException.class);
 

--- a/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
@@ -27,11 +27,12 @@ class SubmissionFieldPreparersTest {
   }
 
   @Test
-  void customPreparerFieldsShouldComeAfterDefaultPreparerFields() {
+  void submissionFieldPreparersShouldCreateSubmissionFieldsForAllFieldsInAPdfMapConfigurationWhileOverwritingDefaultFieldsWithCustomFieldsThatPrepareTheSameInput() {
     submission = Submission.builder().flow("flow1")
         .inputData(
             Map.of(
-                "fieldThatGetsOverwritten", "willBeOverwritten"
+                "fieldThatGetsOverwritten", "willBeOverwritten",
+                "fieldThatDoesNotGetOverwritten", "willNotBeOverwritten"
             )).build();
 
     OneToOnePreparer defaultSingleFieldPreparer = new OneToOnePreparer(pdfMapConfiguration);
@@ -40,8 +41,15 @@ class SubmissionFieldPreparersTest {
     SubmissionFieldPreparers submissionFieldPreparers = new SubmissionFieldPreparers(List.of(defaultSingleFieldPreparer),
         List.of(testCustomPreparer));
 
-    assertThat(submissionFieldPreparers.prepareSubmissionFields(submission)).containsExactly(
-        new SingleField("fieldThatGetsOverwritten", "willBeOverwritten", null),
+    assertThat(defaultSingleFieldPreparer.prepareSubmissionFields(submission)).containsExactly(
+        Map.entry("fieldThatGetsOverwritten", new SingleField("fieldThatGetsOverwritten", "willBeOverwritten", null)),
+        Map.entry("fieldThatDoesNotGetOverwritten", new SingleField("fieldThatGetsOverwritten", "willNotBeOverwritten", null))
+    );
+    assertThat(testCustomPreparer.prepareSubmissionFields(submission)).containsExactly(
+        Map.entry("fieldThatGetsOverwritten", new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null))
+    );
+    assertThat(submissionFieldPreparers.prepareSubmissionFields(submission)).containsExactlyInAnyOrder(
+        new SingleField("fieldThatDoesNotGetOverwritten", "willNotBeOverwritten", null),
         new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null)
     );
   }

--- a/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
@@ -1,0 +1,48 @@
+package formflow.library.pdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SubmissionFieldPreparersTest {
+
+  PdfMapConfiguration pdfMapConfiguration;
+  Submission submission;
+
+  @BeforeEach
+  void setUp() {
+    PdfMap pdfMap = new PdfMap();
+    pdfMap.setInputFields(Map.of(
+            "fieldThatGetsOverwritten", "TEST_FIELD",
+            "fieldThatDoesNotGetOverwritten", "TEST_FIELD_2"
+        )
+    );
+
+    pdfMap.setFlow("flow1");
+    pdfMapConfiguration = new PdfMapConfiguration(List.of(pdfMap));
+  }
+
+  @Test
+  void customPreparerFieldsShouldComeAfterDefaultPreparerFields() {
+    submission = Submission.builder().flow("flow1")
+        .inputData(
+            Map.of(
+                "fieldThatGetsOverwritten", "willBeOverwritten"
+            )).build();
+
+    OneToOnePreparer defaultSingleFieldPreparer = new OneToOnePreparer(pdfMapConfiguration);
+    TestCustomPreparer testCustomPreparer = new TestCustomPreparer();
+
+    SubmissionFieldPreparers submissionFieldPreparers = new SubmissionFieldPreparers(List.of(defaultSingleFieldPreparer),
+        List.of(testCustomPreparer));
+
+    assertThat(submissionFieldPreparers.prepareSubmissionFields(submission)).containsExactly(
+        new SingleField("fieldThatGetsOverwritten", "willBeOverwritten", null),
+        new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null)
+    );
+  }
+}

--- a/src/test/java/formflow/library/pdf/TestCustomPreparer.java
+++ b/src/test/java/formflow/library/pdf/TestCustomPreparer.java
@@ -1,0 +1,12 @@
+package formflow.library.pdf;
+
+import formflow.library.data.Submission;
+import java.util.List;
+
+public class TestCustomPreparer implements SubmissionFieldPreparer {
+
+  @Override
+  public List<SubmissionField> prepareSubmissionFields(Submission submission) {
+    return List.of(new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null));
+  }
+}

--- a/src/test/java/formflow/library/pdf/TestCustomPreparer.java
+++ b/src/test/java/formflow/library/pdf/TestCustomPreparer.java
@@ -1,12 +1,14 @@
 package formflow.library.pdf;
 
 import formflow.library.data.Submission;
-import java.util.List;
+import java.util.HashMap;
 
 public class TestCustomPreparer implements SubmissionFieldPreparer {
 
   @Override
-  public List<SubmissionField> prepareSubmissionFields(Submission submission) {
-    return List.of(new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null));
+  public HashMap<String, SubmissionField> prepareSubmissionFields(Submission submission) {
+    HashMap<String, SubmissionField> testFieldMap = new HashMap<>();
+    testFieldMap.put("fieldThatGetsOverwritten", new SingleField("fieldThatGetsOverwritten", "OVERWRITTEN", null));
+    return testFieldMap;
   }
 }


### PR DESCRIPTION
Addresses:  https://www.pivotaltracker.com/story/show/184688213

- Adds DefaultSubmissionFieldPreparer for library default preparers (OneToOne, OneToMany, and DataBaseFieldPreparer's)
- Application specific preparers should now implement SubmissionFieldPreparer
- The SubmissionFieldPreparers class now has a list of SubmissionFieldPreparer's which will only be custom ones from applications implementing that interface and a list of DefaultSubmissionFieldPreparer's which will be all the library default preparers