### PR TITLE
Support "go back" in a subflow iteration

### DIFF
--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -228,6 +228,8 @@ public class ScreenController extends FormFlowController {
     Map<String, Object> model = createModel(flow, screen, httpSession, submission);
     var currentObject = submission.getSubflowEntryByUuid(currentScreen.getSubflow(), uuid);
     model.put("currentSubflowItem", currentObject);
+    // createModel sets fieldData to submission.inputData; override fieldData with the subflow's data
+    model.put("fieldData", currentObject);
     model.put("formAction", String.format("/flow/%s/%s/%s", flow, screen, uuid));
     return new ModelAndView(String.format("%s/%s", flow, screen), model);
   }
@@ -582,6 +584,8 @@ public class ScreenController extends FormFlowController {
 
     model.put("submission", submission);
     model.put("inputData", submission.getInputData());
+    // default fieldData to "inputData", but it might be replaced with subflow data later on
+    model.put("fieldData", submission.getInputData());
     model.put("errorMessages", httpSession.getAttribute("errorMessages"));
 
     return model;

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -291,6 +291,8 @@ public class ScreenController extends FormFlowController {
     // TODO: validate addresses
 
     if (httpSession.getAttribute("id") != null) {
+      Boolean iterationIsComplete = !isNextScreenInSubflow(flow, httpSession, currentScreen, iterationUuid);
+      formSubmission.getFormData().put("iterationIsComplete", iterationIsComplete);
       // have we submitted any data to the subflow yet?
       if (!submission.getInputData().containsKey(subflowName)) {
         submission.getInputData().put(subflowName, new ArrayList<Map<String, Object>>());
@@ -306,8 +308,6 @@ public class ScreenController extends FormFlowController {
           submission.removeIncompleteIterations(subflowName, iterationUuid);
         }
       }
-      Boolean iterationIsComplete = !isNextScreenInSubflow(flow, httpSession, currentScreen);
-      formSubmission.getFormData().put("iterationIsComplete", iterationIsComplete);
     } else {
       if (isNewIteration) {
         submission.setFlow(flow);
@@ -330,8 +330,8 @@ public class ScreenController extends FormFlowController {
     saveToRepository(submission, subflowName);
     httpSession.setAttribute("id", submission.getId());
 
-    String nextScreen = getNextScreenName(flow, httpSession, currentScreen);
-    String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen) ?
+    String nextScreen = getNextScreenName(httpSession, currentScreen, iterationUuid);
+    String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen, iterationUuid) ?
         String.format("redirect:/flow/%s/%s/%s", flow, nextScreen, iterationUuid)
         : String.format("redirect:/flow/%s/%s", flow, nextScreen);
     return new ModelAndView(viewString);

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -554,12 +554,9 @@ public class ScreenController extends FormFlowController {
     // Put subflow on model if on subflow delete confirmation screen
     HashMap<String, SubflowConfiguration> subflows = getFlowConfigurationByName(flow).getSubflows();
     if (subflows != null) {
-      List<String> subflowFromDeleteConfirmationConfig = subflows
-          .entrySet()
-          .stream()
+      List<String> subflowFromDeleteConfirmationConfig = subflows.entrySet().stream()
           .filter(entry ->
-              entry
-                  .getValue()
+              entry.getValue()
                   .getDeleteConfirmationScreen()
                   .equals(screen))
           .map(Entry::getKey)

--- a/src/main/java/formflow/library/data/FormSubmission.java
+++ b/src/main/java/formflow/library/data/FormSubmission.java
@@ -53,8 +53,10 @@ public class FormSubmission {
    * @return List of Strings representing the validate field name
    */
   public List<String> getAddressValidationFields() {
-    return formData.entrySet().stream().filter(entry -> entry.getKey().startsWith(UnvalidatedField.VALIDATE_ADDRESS))
-        .filter(entry -> entry.getValue().toString().equalsIgnoreCase("true")).map(Entry::getKey).toList();
+    return formData.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(UnvalidatedField.VALIDATE_ADDRESS))
+        .filter(entry -> entry.getValue().toString().equalsIgnoreCase("true"))
+        .map(Entry::getKey).toList();
   }
 
   public void setValidatedAddress(Map<String, ValidatedAddress> validatedAddresses) {

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -38,23 +38,4 @@ public class InputUtils {
 
     return false;
   }
-
-  /**
-   * Static function that returns a Map of input data for use in the current thymeleaf template. If you are in a subflow, the Map
-   * will be set to Submission's `currentSubflowItem` data, otherwise the Map will be set to the Submission's `inputData`.
-   *
-   * @param uiData the WebEngineContext that includes all data passed to the thymeleaf template
-   * @return `currentSubflowItem`'s data if it is not null, otherwise it will be the full `inputData` map
-   */
-  public static Map<String, Object> getFieldData(WebEngineContext uiData) {
-    if (uiData != null) {
-      if (uiData.getVariable("currentSubflowItem") != null) {
-        return (Map) uiData.getVariable("currentSubflowItem");
-      } else if (uiData.getVariable("inputData") != null) {
-        return (Map) uiData.getVariable("inputData");
-      }
-    }
-    log.warn("No data could be found for use in templates.");
-    return Map.of();
-  }
 }

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -1,15 +1,10 @@
 package formflow.library.utils;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
-import java.util.Map;
-import org.thymeleaf.context.WebEngineContext;
 
 /**
  * Utility class to help with parsing input from forms
  */
-@Slf4j
 public class InputUtils {
 
   /**

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Map;
+import org.thymeleaf.context.WebEngineContext;
 
 /**
  * Utility class to help with parsing input from forms
@@ -11,49 +12,61 @@ import java.util.Map;
 @Slf4j
 public class InputUtils {
 
-    /**
-     * Static function to help determine if a String or ArrayList contains the {@code target} value.
-     *
-     * <p>
-     * Currently this performs a comparison between two data types:
-     *     <ul>
-     *         <li>String - checks if the {@code value} equals the {@code target} </li>
-     *         <li>ArrayList of Strings - checks if the {@code target} is in the ArrayList</li>
-     *     </ul>
-     * </p>
-     *
-     * @param value  Object to check if it equals or contains the {@code target} string
-     * @param target string to find in {@code target}
-     * @return true if the {@code target} is equal to or contained in {@code value}, else false
-     */
-    public static boolean arrayOrStringContains(Object value, String target) {
-        if (value instanceof String) {
-            return value.equals(target);
-        }
-
-        if (value instanceof ArrayList) {
-            return ((ArrayList<?>) value).contains(target);
-        }
-
-        return false;
+  /**
+   * Static function to help determine if a String or ArrayList contains the {@code target} value.
+   *
+   * <p>
+   * Currently this performs a comparison between two data types:
+   *     <ul>
+   *         <li>String - checks if the {@code value} equals the {@code target} </li>
+   *         <li>ArrayList of Strings - checks if the {@code target} is in the ArrayList</li>
+   *     </ul>
+   * </p>
+   *
+   * @param value  Object to check if it equals or contains the {@code target} string
+   * @param target string to find in {@code target}
+   * @return true if the {@code target} is equal to or contained in {@code value}, else false
+   */
+  public static boolean arrayOrStringContains(Object value, String target) {
+    if (value instanceof String) {
+      return value.equals(target);
     }
 
-    /**
-     * Static function that returns a Map of input data for use in the thymeleaf template. If you are in a subflow,
-     * the Map will be set to currentSubflowItem and if you are not in a subflow, the Map will be set to
-     * inputData (submission inputData).
-     *
-     * @param currentSubflowItem a Map of input field name to value specific to the current subflow iteration, can be null.
-     * @param inputData          a Map of all input field names to values held in the submission object, can but probably shouldn't be null.
-     * @return currentSubflowItem if it is not null, otherwise inputData.
-     */
-    public static Map<String, Object> getFieldData(Map<String, Object> currentSubflowItem, Map<String, Object> inputData) {
-        if (currentSubflowItem != null) {
-            return currentSubflowItem;
-        } else if (inputData != null) {
-            return inputData;
-        }
-        log.warn("No data could be found for use in templates.");
-        return Map.of();
+    if (value instanceof ArrayList) {
+      return ((ArrayList<?>) value).contains(target);
     }
+
+    return false;
+  }
+
+  /**
+   * Static function that returns a Map of input data for use in the thymeleaf template. If you are in a subflow, the Map will be
+   * set to currentSubflowItem and if you are not in a subflow, the Map will be set to inputData (submission inputData).
+   *
+   * @param currentSubflowItem a Map of input field name to value specific to the current subflow iteration, can be null.
+   * @param inputData          a Map of all input field names to values held in the submission object, can but probably shouldn't
+   *                           be null.
+   * @return currentSubflowItem if it is not null, otherwise inputData.
+   */
+  public static Map<String, Object> getFieldData(Map<String, Object> currentSubflowItem, Map<String, Object> inputData) {
+    if (currentSubflowItem != null) {
+      return currentSubflowItem;
+    } else if (inputData != null) {
+      return inputData;
+    }
+    log.warn("No data could be found for use in templates.");
+    return Map.of();
+  }
+
+  public static Map<String, Object> getFieldData(WebEngineContext uiData) {
+    if (uiData != null) {
+      if (uiData.getVariable("currentSubflowItem") != null) {
+        return (Map) uiData.getVariable("currentSubflowItem");
+      } else if (uiData.getVariable("inputData") != null) {
+        return (Map) uiData.getVariable("inputData");
+      }
+    }
+    log.warn("No data could be found for use in templates.");
+    return Map.of();
+  }
 }

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -1,11 +1,14 @@
 package formflow.library.utils;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.Map;
 
 /**
  * Utility class to help with parsing input from forms
  */
+@Slf4j
 public class InputUtils {
 
     /**
@@ -35,12 +38,22 @@ public class InputUtils {
         return false;
     }
 
+    /**
+     * Static function that returns a Map of input data for use in the thymeleaf template. If you are in a subflow,
+     * the Map will be set to currentSubflowItem and if you are not in a subflow, the Map will be set to
+     * inputData (submission inputData).
+     *
+     * @param currentSubflowItem a Map of input field name to value specific to the current subflow iteration, can be null.
+     * @param inputData          a Map of all input field names to values held in the submission object, can but probably shouldn't be null.
+     * @return currentSubflowItem if it is not null, otherwise inputData.
+     */
     public static Map<String, Object> getFieldData(Map<String, Object> currentSubflowItem, Map<String, Object> inputData) {
         if (currentSubflowItem != null) {
             return currentSubflowItem;
         } else if (inputData != null) {
             return inputData;
         }
+        log.warn("No data could be found for use in templates.");
         return Map.of();
     }
 }

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -33,4 +33,8 @@ public class InputUtils {
 
     return false;
   }
+
+  public static String getFieldData() {
+
+  }
 }

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -1,40 +1,46 @@
 package formflow.library.utils;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * Utility class to help with parsing input from forms
  */
 public class InputUtils {
 
-  /**
-   * Static function to help determine if a String or ArrayList contains the {@code target} value.
-   *
-   * <p>
-   * Currently this performs a comparison between two data types:
-   *     <ul>
-   *         <li>String - checks if the {@code value} equals the {@code target} </li>
-   *         <li>ArrayList of Strings - checks if the {@code target} is in the ArrayList</li>
-   *     </ul>
-   * </p>
-   *
-   * @param value  Object to check if it equals or contains the {@code target} string
-   * @param target string to find in {@code target}
-   * @return true if the {@code target} is equal to or contained in {@code value}, else false
-   */
-  public static boolean arrayOrStringContains(Object value, String target) {
-    if (value instanceof String) {
-      return value.equals(target);
+    /**
+     * Static function to help determine if a String or ArrayList contains the {@code target} value.
+     *
+     * <p>
+     * Currently this performs a comparison between two data types:
+     *     <ul>
+     *         <li>String - checks if the {@code value} equals the {@code target} </li>
+     *         <li>ArrayList of Strings - checks if the {@code target} is in the ArrayList</li>
+     *     </ul>
+     * </p>
+     *
+     * @param value  Object to check if it equals or contains the {@code target} string
+     * @param target string to find in {@code target}
+     * @return true if the {@code target} is equal to or contained in {@code value}, else false
+     */
+    public static boolean arrayOrStringContains(Object value, String target) {
+        if (value instanceof String) {
+            return value.equals(target);
+        }
+
+        if (value instanceof ArrayList) {
+            return ((ArrayList<?>) value).contains(target);
+        }
+
+        return false;
     }
 
-    if (value instanceof ArrayList) {
-      return ((ArrayList<?>) value).contains(target);
+    public static Map<String, Object> getFieldData(Map<String, Object> currentSubflowItem, Map<String, Object> inputData) {
+        if (currentSubflowItem != null) {
+            return currentSubflowItem;
+        } else if (inputData != null) {
+            return inputData;
+        }
+        return Map.of();
     }
-
-    return false;
-  }
-
-  public static String getFieldData() {
-
-  }
 }

--- a/src/main/java/formflow/library/utils/InputUtils.java
+++ b/src/main/java/formflow/library/utils/InputUtils.java
@@ -40,24 +40,12 @@ public class InputUtils {
   }
 
   /**
-   * Static function that returns a Map of input data for use in the thymeleaf template. If you are in a subflow, the Map will be
-   * set to currentSubflowItem and if you are not in a subflow, the Map will be set to inputData (submission inputData).
+   * Static function that returns a Map of input data for use in the current thymeleaf template. If you are in a subflow, the Map
+   * will be set to Submission's `currentSubflowItem` data, otherwise the Map will be set to the Submission's `inputData`.
    *
-   * @param currentSubflowItem a Map of input field name to value specific to the current subflow iteration, can be null.
-   * @param inputData          a Map of all input field names to values held in the submission object, can but probably shouldn't
-   *                           be null.
-   * @return currentSubflowItem if it is not null, otherwise inputData.
+   * @param uiData the WebEngineContext that includes all data passed to the thymeleaf template
+   * @return `currentSubflowItem`'s data if it is not null, otherwise it will be the full `inputData` map
    */
-  public static Map<String, Object> getFieldData(Map<String, Object> currentSubflowItem, Map<String, Object> inputData) {
-    if (currentSubflowItem != null) {
-      return currentSubflowItem;
-    } else if (inputData != null) {
-      return inputData;
-    }
-    log.warn("No data could be found for use in templates.");
-    return Map.of();
-  }
-
   public static Map<String, Object> getFieldData(WebEngineContext uiData) {
     if (uiData != null) {
       if (uiData.getVariable("currentSubflowItem") != null) {

--- a/src/main/resources/templates/fragments/inputs/checkbox.html
+++ b/src/main/resources/templates/fragments/inputs/checkbox.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="checkbox"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
@@ -16,34 +15,34 @@
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:for="${inputName} + '-' + ${value}"
-               th:id="${inputName} + '-' + ${value} + '-label'"
-               class="checkbox display-flex">
-            <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${name}" value="">
-            <input type="checkbox"
-                   th:id="${inputName} + '-' + ${value}"
-                   th:value="${value}"
-                   th:name="${name}"
-                   th:with="checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(fieldData.getOrDefault(name, ''), value)}"
-                   th:checked="${checked}"
-                   th:attr="
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:for="${inputName} + '-' + ${value}"
+           th:id="${inputName} + '-' + ${value} + '-label'"
+           class="checkbox display-flex">
+      <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${name}" value="">
+      <input type="checkbox"
+             th:id="${inputName} + '-' + ${value}"
+             th:value="${value}"
+             th:name="${name}"
+             th:with="checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(fieldData.getOrDefault(name, ''), value)}"
+             th:checked="${checked}"
+             th:attr="
               aria-invalid=${hasError},
               data-follow-up=${followUpId}">
-            <div th:if="${hasIcon}">
-                <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
-            </div>
-            <div>
-                <span th:text="${label}"></span>
-                <p th:if="${hasHelpText}"
-                   th:id="${name} + '-' + ${value} + '-help-text'"
-                   th:text="${checkboxHelpText}"
-                   class="text--help with-no-padding"></p>
-            </div>
-        </label>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+      <div th:if="${hasIcon}">
+        <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
+      </div>
+      <div>
+        <span th:text="${label}"></span>
+        <p th:if="${hasHelpText}"
+           th:id="${name} + '-' + ${value} + '-help-text'"
+           th:text="${checkboxHelpText}"
+           class="text--help with-no-padding"></p>
+      </div>
+    </label>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/checkbox.html
+++ b/src/main/resources/templates/fragments/inputs/checkbox.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="checkbox"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="checkbox"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
@@ -12,7 +12,7 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="
+    th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
@@ -42,7 +42,7 @@
             </div>
         </label>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/inputs/checkbox.html
+++ b/src/main/resources/templates/fragments/inputs/checkbox.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="checkbox"
-    th:with="
+        th:fragment="checkbox"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
@@ -11,38 +12,38 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="
+        th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:for="${inputName} + '-' + ${value}"
-           th:id="${inputName} + '-' + ${value} + '-label'"
-           class="checkbox display-flex">
-      <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${name}" value="">
-      <input type="checkbox"
-             th:id="${inputName} + '-' + ${value}"
-             th:value="${value}"
-             th:name="${name}"
-             th:with="checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(inputData.getOrDefault(name, ''), value)}"
-             th:checked="${checked}"
-             th:attr="
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:for="${inputName} + '-' + ${value}"
+               th:id="${inputName} + '-' + ${value} + '-label'"
+               class="checkbox display-flex">
+            <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${name}" value="">
+            <input type="checkbox"
+                   th:id="${inputName} + '-' + ${value}"
+                   th:value="${value}"
+                   th:name="${name}"
+                   th:with="checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(fieldData.getOrDefault(name, ''), value)}"
+                   th:checked="${checked}"
+                   th:attr="
               aria-invalid=${hasError},
               data-follow-up=${followUpId}">
-      <div th:if="${hasIcon}">
-        <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
-      </div>
-      <div>
-        <span th:text="${label}"></span>
-        <p th:if="${hasHelpText}"
-           th:id="${name} + '-' + ${value} + '-help-text'"
-           th:text="${checkboxHelpText}"
-           class="text--help with-no-padding"></p>
-      </div>
-    </label>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+            <div th:if="${hasIcon}">
+                <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
+            </div>
+            <div>
+                <span th:text="${label}"></span>
+                <p th:if="${hasHelpText}"
+                   th:id="${name} + '-' + ${value} + '-help-text'"
+                   th:text="${checkboxHelpText}"
+                   class="text--help with-no-padding"></p>
+            </div>
+        </label>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -4,11 +4,11 @@
 <th:block
         th:fragment="checkboxInSet"
         th:with="
-      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
-      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(data.getOrDefault(name, ''), value)},
+      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(fieldData.getOrDefault(name, ''), value)},
       id=${#bools.isTrue(noneOfTheAbove) ? 'none__checkbox' : inputName + '-' + value}"
         th:assert="
       ${!#strings.isEmpty(inputName)},

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -2,15 +2,15 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="checkboxInSet"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="checkboxInSet"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
       checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(fieldData.getOrDefault(name, ''), value)},
       id=${#bools.isTrue(noneOfTheAbove) ? 'none__checkbox' : inputName + '-' + value}"
-        th:assert="
+    th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -4,10 +4,11 @@
 <th:block
     th:fragment="checkboxInSet"
     th:with="
+      data=${T(formflow.library.utils.InputUtils).getData(model)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
-      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(inputData.getOrDefault(name, ''), value)},
+      checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(data.getOrDefault(name, ''), value)},
       id=${#bools.isTrue(noneOfTheAbove) ? 'none__checkbox' : inputName + '-' + value}"
     th:assert="
       ${!#strings.isEmpty(inputName)},

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -2,40 +2,40 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="checkboxInSet"
-    th:with="
-      data=${T(formflow.library.utils.InputUtils).getData(model)},
+        th:fragment="checkboxInSet"
+        th:with="
+      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
       checked=${T(formflow.library.utils.InputUtils).arrayOrStringContains(data.getOrDefault(name, ''), value)},
       id=${#bools.isTrue(noneOfTheAbove) ? 'none__checkbox' : inputName + '-' + value}"
-    th:assert="
+        th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-  <label th:for="${id}"
-         th:id="${id} + '-label'"
-         class="checkbox display-flex">
-    <input type="checkbox"
-           th:id="${id}"
-           th:value="${value}"
-           th:name="${name}"
-           th:checked="${checked}"
-           th:attr="
+    <label th:for="${id}"
+           th:id="${id} + '-label'"
+           class="checkbox display-flex">
+        <input type="checkbox"
+               th:id="${id}"
+               th:value="${value}"
+               th:name="${name}"
+               th:checked="${checked}"
+               th:attr="
             aria-invalid=${hasError},
             data-follow-up=${followUpId}">
-    <div th:if="${hasIcon}">
-      <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
-    </div>
-    <div>
-      <span th:text="${label}"></span>
-      <p th:if="${hasHelpText}"
-         th:id="${id} + '-help-text'"
-         th:text="${checkboxHelpText}"
-         class="text--help with-no-padding"></p>
-    </div>
-  </label>
+        <div th:if="${hasIcon}">
+            <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
+        </div>
+        <div>
+            <span th:text="${label}"></span>
+            <p th:if="${hasHelpText}"
+               th:id="${id} + '-help-text'"
+               th:text="${checkboxHelpText}"
+               class="text--help with-no-padding"></p>
+        </div>
+    </label>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/checkboxInSet.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxInSet.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="checkboxInSet"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(checkboxHelpText)},
       hasIcon=${!#strings.isEmpty(checkboxIcon)},
       name=${inputName} + '[]',
@@ -14,28 +13,28 @@
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-    <label th:for="${id}"
-           th:id="${id} + '-label'"
-           class="checkbox display-flex">
-        <input type="checkbox"
-               th:id="${id}"
-               th:value="${value}"
-               th:name="${name}"
-               th:checked="${checked}"
-               th:attr="
+  <label th:for="${id}"
+         th:id="${id} + '-label'"
+         class="checkbox display-flex">
+    <input type="checkbox"
+           th:id="${id}"
+           th:value="${value}"
+           th:name="${name}"
+           th:checked="${checked}"
+           th:attr="
             aria-invalid=${hasError},
             data-follow-up=${followUpId}">
-        <div th:if="${hasIcon}">
-            <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
-        </div>
-        <div>
-            <span th:text="${label}"></span>
-            <p th:if="${hasHelpText}"
-               th:id="${id} + '-help-text'"
-               th:text="${checkboxHelpText}"
-               class="text--help with-no-padding"></p>
-        </div>
-    </label>
+    <div th:if="${hasIcon}">
+      <i th:class="${'icon-' + checkboxIcon}" style="margin-right: 0.5rem"></i>
+    </div>
+    <div>
+      <span th:text="${label}"></span>
+      <p th:if="${hasHelpText}"
+         th:id="${id} + '-help-text'"
+         th:text="${checkboxHelpText}"
+         class="text--help with-no-padding"></p>
+    </div>
+  </label>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/date.html
+++ b/src/main/resources/templates/fragments/inputs/date.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="date(inputName, groupName)"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="date(inputName, groupName)"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
       hasErrorMonth=${
@@ -19,11 +19,12 @@
         errorMessages != null &&
         errorMessages.get(inputName + 'Year') != null &&
         #arrays.length(errorMessages.get(inputName + 'Year')) > 0 }"
-        th:assert="${hasLabel || hasAriaLabel}">
+    th:assert="${hasLabel || hasAriaLabel}">
     <div
-            th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
+        th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
         <fieldset th:id="${groupName}" class="input-group input-group--inline">
-            <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+            <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}"
+                   class="form-question"/>
             <p class="text--help">
                 <label th:for="${inputName}+'-month'"
                        th:id="${inputName}+'-month-label'"
@@ -72,13 +73,13 @@
                    th:value="${fieldData.getOrDefault(inputName + 'Year', '')}"/>
         </fieldset>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
     </div>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/inputs/date.html
+++ b/src/main/resources/templates/fragments/inputs/date.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="date(inputName, groupName)"
-    th:with="
+        th:fragment="date(inputName, groupName)"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
       hasErrorMonth=${
@@ -18,67 +19,67 @@
         errorMessages != null &&
         errorMessages.get(inputName + 'Year') != null &&
         #arrays.length(errorMessages.get(inputName + 'Year')) > 0 }"
-    th:assert="${hasLabel || hasAriaLabel}">
-  <div
-      th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
-    <fieldset th:id="${groupName}" class="input-group input-group--inline">
-      <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-      <p class="text--help">
-        <label th:for="${inputName}+'-month'"
-               th:id="${inputName}+'-month-label'"
-               th:text="#{general.month}"></label>
-        &nbsp;/&nbsp;
-        <label th:for="${inputName}+'-day'"
-               th:id="${inputName}+'-day-label'"
-               th:text="#{general.day}"></label>
-        &nbsp;/&nbsp;
-        <label th:for="${inputName}+'-year'"
-               th:id="${inputName}+'-year-label'"
-               th:text="#{general.year}"></label>
-      </p>
-      <!-- TODO: figure out the three fields for each date issue -->
-      <input type="text" inputmode="numeric" maxlength="2"
-             class="text-input text-input--inline form-width--month"
-             th:id="${inputName}+'-month'"
-             th:name="${inputName}+'Month'"
-             th:placeholder="mm"
-             th:attr="
+        th:assert="${hasLabel || hasAriaLabel}">
+    <div
+            th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
+        <fieldset th:id="${groupName}" class="input-group input-group--inline">
+            <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+            <p class="text--help">
+                <label th:for="${inputName}+'-month'"
+                       th:id="${inputName}+'-month-label'"
+                       th:text="#{general.month}"></label>
+                &nbsp;/&nbsp;
+                <label th:for="${inputName}+'-day'"
+                       th:id="${inputName}+'-day-label'"
+                       th:text="#{general.day}"></label>
+                &nbsp;/&nbsp;
+                <label th:for="${inputName}+'-year'"
+                       th:id="${inputName}+'-year-label'"
+                       th:text="#{general.year}"></label>
+            </p>
+            <!-- TODO: figure out the three fields for each date issue -->
+            <input type="text" inputmode="numeric" maxlength="2"
+                   class="text-input text-input--inline form-width--month"
+                   th:id="${inputName}+'-month'"
+                   th:name="${inputName}+'Month'"
+                   th:placeholder="mm"
+                   th:attr="
               aria-describedby=${inputName + '-month-label'},
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorMonth}"
-             th:value="${inputData.getOrDefault(inputName + 'Month', '')}"/>
-      /
-      <input type="text" inputmode="numeric" maxlength="2"
-             class="text-input text-input--inline form-width--day"
-             th:id="${inputName}+'-day'"
-             th:name="${inputName}+'Day'"
-             th:placeholder="dd"
-             th:attr="
+                   th:value="${fieldData.getOrDefault(inputName + 'Month', '')}"/>
+            /
+            <input type="text" inputmode="numeric" maxlength="2"
+                   class="text-input text-input--inline form-width--day"
+                   th:id="${inputName}+'-day'"
+                   th:name="${inputName}+'Day'"
+                   th:placeholder="dd"
+                   th:attr="
               aria-describedby=${inputName}+'-day-label',
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorDay}"
-             th:value="${inputData.getOrDefault(inputName + 'Day', '')}"/>
-      /
-      <input type="text" inputmode="numeric" maxlength="4"
-             class="text-input text-input--inline form-width--year"
-             th:id="${inputName}+'-year'"
-             th:name="${inputName}+ 'Year'"
-             th:placeholder="yyyy"
-             th:attr="
+                   th:value="${fieldData.getOrDefault(inputName + 'Day', '')}"/>
+            /
+            <input type="text" inputmode="numeric" maxlength="4"
+                   class="text-input text-input--inline form-width--year"
+                   th:id="${inputName}+'-year'"
+                   th:name="${inputName}+ 'Year'"
+                   th:placeholder="yyyy"
+                   th:attr="
               aria-describedby=${inputName}+'-year-label',
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorYear}"
-             th:value="${inputData.getOrDefault(inputName + 'Year', '')}"/>
-    </fieldset>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
-  </div>
+                   th:value="${fieldData.getOrDefault(inputName + 'Year', '')}"/>
+        </fieldset>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/date.html
+++ b/src/main/resources/templates/fragments/inputs/date.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="date(inputName, groupName)"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
       hasErrorMonth=${
@@ -20,67 +19,67 @@
         errorMessages.get(inputName + 'Year') != null &&
         #arrays.length(errorMessages.get(inputName + 'Year')) > 0 }"
     th:assert="${hasLabel || hasAriaLabel}">
-    <div
-        th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
-        <fieldset th:id="${groupName}" class="input-group input-group--inline">
-            <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}"
-                   class="form-question"/>
-            <p class="text--help">
-                <label th:for="${inputName}+'-month'"
-                       th:id="${inputName}+'-month-label'"
-                       th:text="#{general.month}"></label>
-                &nbsp;/&nbsp;
-                <label th:for="${inputName}+'-day'"
-                       th:id="${inputName}+'-day-label'"
-                       th:text="#{general.day}"></label>
-                &nbsp;/&nbsp;
-                <label th:for="${inputName}+'-year'"
-                       th:id="${inputName}+'-year-label'"
-                       th:text="#{general.year}"></label>
-            </p>
-            <!-- TODO: figure out the three fields for each date issue -->
-            <input type="text" inputmode="numeric" maxlength="2"
-                   class="text-input text-input--inline form-width--month"
-                   th:id="${inputName}+'-month'"
-                   th:name="${inputName}+'Month'"
-                   th:placeholder="mm"
-                   th:attr="
+  <div
+      th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
+    <fieldset th:id="${groupName}" class="input-group input-group--inline">
+      <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}"
+             class="form-question"/>
+      <p class="text--help">
+        <label th:for="${inputName}+'-month'"
+               th:id="${inputName}+'-month-label'"
+               th:text="#{general.month}"></label>
+        &nbsp;/&nbsp;
+        <label th:for="${inputName}+'-day'"
+               th:id="${inputName}+'-day-label'"
+               th:text="#{general.day}"></label>
+        &nbsp;/&nbsp;
+        <label th:for="${inputName}+'-year'"
+               th:id="${inputName}+'-year-label'"
+               th:text="#{general.year}"></label>
+      </p>
+      <!-- TODO: figure out the three fields for each date issue -->
+      <input type="text" inputmode="numeric" maxlength="2"
+             class="text-input text-input--inline form-width--month"
+             th:id="${inputName}+'-month'"
+             th:name="${inputName}+'Month'"
+             th:placeholder="mm"
+             th:attr="
               aria-describedby=${inputName + '-month-label'},
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorMonth}"
-                   th:value="${fieldData.getOrDefault(inputName + 'Month', '')}"/>
-            /
-            <input type="text" inputmode="numeric" maxlength="2"
-                   class="text-input text-input--inline form-width--day"
-                   th:id="${inputName}+'-day'"
-                   th:name="${inputName}+'Day'"
-                   th:placeholder="dd"
-                   th:attr="
+             th:value="${fieldData.getOrDefault(inputName + 'Month', '')}"/>
+      /
+      <input type="text" inputmode="numeric" maxlength="2"
+             class="text-input text-input--inline form-width--day"
+             th:id="${inputName}+'-day'"
+             th:name="${inputName}+'Day'"
+             th:placeholder="dd"
+             th:attr="
               aria-describedby=${inputName}+'-day-label',
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorDay}"
-                   th:value="${fieldData.getOrDefault(inputName + 'Day', '')}"/>
-            /
-            <input type="text" inputmode="numeric" maxlength="4"
-                   class="text-input text-input--inline form-width--year"
-                   th:id="${inputName}+'-year'"
-                   th:name="${inputName}+ 'Year'"
-                   th:placeholder="yyyy"
-                   th:attr="
+             th:value="${fieldData.getOrDefault(inputName + 'Day', '')}"/>
+      /
+      <input type="text" inputmode="numeric" maxlength="4"
+             class="text-input text-input--inline form-width--year"
+             th:id="${inputName}+'-year'"
+             th:name="${inputName}+ 'Year'"
+             th:placeholder="yyyy"
+             th:attr="
               aria-describedby=${inputName}+'-year-label',
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasErrorYear}"
-                   th:value="${fieldData.getOrDefault(inputName + 'Year', '')}"/>
-        </fieldset>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
-    </div>
+             th:value="${fieldData.getOrDefault(inputName + 'Year', '')}"/>
+    </fieldset>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Month')}"></th:block>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Day')}"></th:block>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName} + 'Year')}"></th:block>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${groupName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/money.html
+++ b/src/main/resources/templates/fragments/inputs/money.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="money"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="money"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -12,7 +12,7 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
     <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
         <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
         <p class="text--help"
@@ -32,7 +32,7 @@
                    th:value="${fieldData.getOrDefault(inputName, '')}">
         </div>
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/inputs/money.html
+++ b/src/main/resources/templates/fragments/inputs/money.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="money"
-    th:with="
+        th:fragment="money"
+        th:with="
+      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -11,28 +12,28 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <div class="text-input-group form-width--med">
-      <div class="text-input-group__prefix">$</div>
-      <input type="text" class="text-input"
-             th:id="${inputName}"
-             th:name="${inputName}"
-             th:placeholder="${placeholder}"
-             th:attr="
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <div class="text-input-group form-width--med">
+            <div class="text-input-group__prefix">$</div>
+            <input type="text" class="text-input"
+                   th:id="${inputName}"
+                   th:name="${inputName}"
+                   th:placeholder="${placeholder}"
+                   th:attr="
               aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasError}"
-             th:value="${inputData.getOrDefault(inputName, '')}">
+                   th:value="${data.getOrDefault(inputName, '')}">
+        </div>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/money.html
+++ b/src/main/resources/templates/fragments/inputs/money.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="money"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -13,27 +12,27 @@
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
     th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <div class="text-input-group form-width--med">
-            <div class="text-input-group__prefix">$</div>
-            <input type="text" class="text-input"
-                   th:id="${inputName}"
-                   th:name="${inputName}"
-                   th:placeholder="${placeholder}"
-                   th:attr="
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <div class="text-input-group form-width--med">
+      <div class="text-input-group__prefix">$</div>
+      <input type="text" class="text-input"
+             th:id="${inputName}"
+             th:name="${inputName}"
+             th:placeholder="${placeholder}"
+             th:attr="
               aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasError}"
-                   th:value="${fieldData.getOrDefault(inputName, '')}">
-        </div>
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+             th:value="${fieldData.getOrDefault(inputName, '')}">
     </div>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/money.html
+++ b/src/main/resources/templates/fragments/inputs/money.html
@@ -4,7 +4,7 @@
 <th:block
         th:fragment="money"
         th:with="
-      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -29,7 +29,7 @@
               aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
               aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
               aria-invalid=${hasError}"
-                   th:value="${data.getOrDefault(inputName, '')}">
+                   th:value="${fieldData.getOrDefault(inputName, '')}">
         </div>
         <th:block
                 th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>

--- a/src/main/resources/templates/fragments/inputs/number.html
+++ b/src/main/resources/templates/fragments/inputs/number.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="number"
-    th:with="
+        th:fragment="number"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasTitle=${!#strings.isEmpty(title)},
       hasPattern=${!#strings.isEmpty(pattern)},
@@ -13,28 +14,28 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)},, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <input type="text" inputmode="numeric"
-           class="text-input form-width--med"
-           th:id="${inputName}"
-           th:name="${inputName}"
-           th:placeholder="${placeholder}"
-           th:attr="
+        th:assert="${!#strings.isEmpty(inputName)},, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <input type="text" inputmode="numeric"
+               class="text-input form-width--med"
+               th:id="${inputName}"
+               th:name="${inputName}"
+               th:placeholder="${placeholder}"
+               th:attr="
             title=${hasTitle ? title : #messages.msg('general.inputs.number')},
             pattern=${hasPattern ? pattern : '^\d*(\.\d{0,2})?$'},
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-           th:value="${inputData.getOrDefault(inputName, '')}">
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+               th:value="${fieldData.getOrDefault(inputName, '')}">
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/number.html
+++ b/src/main/resources/templates/fragments/inputs/number.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="number"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasTitle=${!#strings.isEmpty(title)},
       hasPattern=${!#strings.isEmpty(pattern)},
@@ -15,27 +14,27 @@
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
     th:assert="${!#strings.isEmpty(inputName)},, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <input type="text" inputmode="numeric"
-               class="text-input form-width--med"
-               th:id="${inputName}"
-               th:name="${inputName}"
-               th:placeholder="${placeholder}"
-               th:attr="
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <input type="text" inputmode="numeric"
+           class="text-input form-width--med"
+           th:id="${inputName}"
+           th:name="${inputName}"
+           th:placeholder="${placeholder}"
+           th:attr="
             title=${hasTitle ? title : #messages.msg('general.inputs.number')},
             pattern=${hasPattern ? pattern : '^\d*(\.\d{0,2})?$'},
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-               th:value="${fieldData.getOrDefault(inputName, '')}">
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+           th:value="${fieldData.getOrDefault(inputName, '')}">
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/number.html
+++ b/src/main/resources/templates/fragments/inputs/number.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="number"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="number"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasTitle=${!#strings.isEmpty(title)},
       hasPattern=${!#strings.isEmpty(pattern)},
@@ -14,7 +14,7 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)},, ${hasLabel || hasAriaLabel}">
+    th:assert="${!#strings.isEmpty(inputName)},, ${hasLabel || hasAriaLabel}">
     <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
         <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
         <p class="text--help"
@@ -34,7 +34,7 @@
             aria-invalid=${hasError}"
                th:value="${fieldData.getOrDefault(inputName, '')}">
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/inputs/phone.html
+++ b/src/main/resources/templates/fragments/inputs/phone.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="phone"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="phone"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -12,25 +12,25 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <input type="tel" class="text-input form-width--med phone-input"
-               th:id="${inputName}"
-               th:name="${inputName}"
-               th:placeholder="${placeholder}"
-               th:attr="
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <input type="tel" class="text-input form-width--med phone-input"
+           th:id="${inputName}"
+           th:name="${inputName}"
+           th:placeholder="${placeholder}"
+           th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-               th:value="${fieldData.getOrDefault(inputName, '')}">
-        <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+           th:value="${fieldData.getOrDefault(inputName, '')}">
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/phone.html
+++ b/src/main/resources/templates/fragments/inputs/phone.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="phone"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},

--- a/src/main/resources/templates/fragments/inputs/phone.html
+++ b/src/main/resources/templates/fragments/inputs/phone.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="phone"
-    th:with="
+        th:fragment="phone"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -11,25 +12,25 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <input type="tel" class="text-input form-width--med phone-input"
-           th:id="${inputName}"
-           th:name="${inputName}"
-           th:placeholder="${placeholder}"
-           th:attr="
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <input type="tel" class="text-input form-width--med phone-input"
+               th:id="${inputName}"
+               th:name="${inputName}"
+               th:placeholder="${placeholder}"
+               th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-           th:value="${inputData.getOrDefault(inputName, '')}">
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+               th:value="${fieldData.getOrDefault(inputName, '')}">
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/radio.html
+++ b/src/main/resources/templates/fragments/inputs/radio.html
@@ -2,29 +2,29 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="radio"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}"
-        th:assert="
+    th:fragment="radio"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}"
+    th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-    <label th:for="${inputName} + '-' + ${value}"
-           th:id="${inputName} + '-' + ${value} + '-label'"
-           th:classappend="${#bools.isTrue(disabled) ? 'disabled' : ''}"
-           class="radio-button">
-        <input type="radio"
-               th:id="${inputName} + '-' + ${value}"
-               th:value="${value}"
-               th:name="${inputName}"
-               th:checked="${fieldData.getOrDefault(inputName, '').equals(value)}"
-               th:disabled="${disabled}"
-               th:aria-disabled="${disabled}"
-               th:attr="
+  <label th:for="${inputName} + '-' + ${value}"
+         th:id="${inputName} + '-' + ${value} + '-label'"
+         th:classappend="${#bools.isTrue(disabled) ? 'disabled' : ''}"
+         class="radio-button">
+    <input type="radio"
+           th:id="${inputName} + '-' + ${value}"
+           th:value="${value}"
+           th:name="${inputName}"
+           th:checked="${fieldData.getOrDefault(inputName, '').equals(value)}"
+           th:disabled="${disabled}"
+           th:aria-disabled="${disabled}"
+           th:attr="
             aria-invalid=${hasError},
             data-follow-up=${followUpId}">
-        <span th:text="${label}"></span>
-    </label>
+    <span th:text="${label}"></span>
+  </label>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/radio.html
+++ b/src/main/resources/templates/fragments/inputs/radio.html
@@ -2,27 +2,29 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="radio"
-    th:assert="
+        th:fragment="radio"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}"
+        th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},
       ${!#strings.isEmpty(label)}">
-  <label th:for="${inputName} + '-' + ${value}"
-         th:id="${inputName} + '-' + ${value} + '-label'"
-         th:classappend="${#bools.isTrue(disabled) ? 'disabled' : ''}"
-         class="radio-button">
-    <input type="radio"
-           th:id="${inputName} + '-' + ${value}"
-           th:value="${value}"
-           th:name="${inputName}"
-           th:checked="${inputData.getOrDefault(inputName, '').equals(value)}"
-           th:disabled="${disabled}"
-           th:aria-disabled="${disabled}"
-           th:attr="
+    <label th:for="${inputName} + '-' + ${value}"
+           th:id="${inputName} + '-' + ${value} + '-label'"
+           th:classappend="${#bools.isTrue(disabled) ? 'disabled' : ''}"
+           class="radio-button">
+        <input type="radio"
+               th:id="${inputName} + '-' + ${value}"
+               th:value="${value}"
+               th:name="${inputName}"
+               th:checked="${fieldData.getOrDefault(inputName, '').equals(value)}"
+               th:disabled="${disabled}"
+               th:aria-disabled="${disabled}"
+               th:attr="
             aria-invalid=${hasError},
             data-follow-up=${followUpId}">
-    <span th:text="${label}"></span>
-  </label>
+        <span th:text="${label}"></span>
+    </label>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/radio.html
+++ b/src/main/resources/templates/fragments/inputs/radio.html
@@ -3,8 +3,6 @@
 <body>
 <th:block
     th:fragment="radio"
-    th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}"
     th:assert="
       ${!#strings.isEmpty(inputName)},
       ${!#strings.isEmpty(value)},

--- a/src/main/resources/templates/fragments/inputs/selectOption.html
+++ b/src/main/resources/templates/fragments/inputs/selectOption.html
@@ -2,15 +2,15 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="selectOption"
-        th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}"
-        th:assert="
+    th:fragment="selectOption"
+    th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}"
+    th:assert="
       ${value != null},
       ${!#strings.isEmpty(optionText)}">
-    <option
-            th:value="${value}"
-            th:selected="${fieldData.getOrDefault(inputName, '').equals(value)}"
-            th:text="${optionText}"></option>
+  <option
+      th:value="${value}"
+      th:selected="${fieldData.getOrDefault(inputName, '').equals(value)}"
+      th:text="${optionText}"></option>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/selectOption.html
+++ b/src/main/resources/templates/fragments/inputs/selectOption.html
@@ -3,7 +3,6 @@
 <body>
 <th:block
     th:fragment="selectOption"
-    th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}"
     th:assert="
       ${value != null},
       ${!#strings.isEmpty(optionText)}">

--- a/src/main/resources/templates/fragments/inputs/selectOption.html
+++ b/src/main/resources/templates/fragments/inputs/selectOption.html
@@ -2,14 +2,15 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="selectOption"
-    th:assert="
+        th:fragment="selectOption"
+        th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}"
+        th:assert="
       ${value != null},
       ${!#strings.isEmpty(optionText)}">
-  <option
-      th:value="${value}"
-      th:selected="${inputData.getOrDefault(inputName, '').equals(value)}"
-      th:text="${optionText}"></option>
+    <option
+            th:value="${value}"
+            th:selected="${fieldData.getOrDefault(inputName, '').equals(value)}"
+            th:text="${optionText}"></option>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/ssn.html
+++ b/src/main/resources/templates/fragments/inputs/ssn.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="ssn"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -13,25 +12,25 @@
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
     th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <input type="text" class="text-input form-width--med ssn-input"
-               th:id="${inputName}"
-               th:name="${inputName}"
-               th:placeholder="${placeholder}"
-               th:attr="
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <input type="text" class="text-input form-width--med ssn-input"
+           th:id="${inputName}"
+           th:name="${inputName}"
+           th:placeholder="${placeholder}"
+           th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-               th:value="${fieldData.getOrDefault(inputName, '')}"
-               inputmode="numeric">
-        <th:block
-            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+           th:value="${fieldData.getOrDefault(inputName, '')}"
+           inputmode="numeric">
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/ssn.html
+++ b/src/main/resources/templates/fragments/inputs/ssn.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="ssn"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="ssn"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -12,7 +12,7 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
     <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
         <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
         <p class="text--help"
@@ -30,7 +30,7 @@
                th:value="${fieldData.getOrDefault(inputName, '')}"
                inputmode="numeric">
         <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+            th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/inputs/ssn.html
+++ b/src/main/resources/templates/fragments/inputs/ssn.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="ssn"
-    th:with="
+        th:fragment="ssn"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -11,26 +12,26 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <input type="text" class="text-input form-width--med ssn-input"
-           th:id="${inputName}"
-           th:name="${inputName}"
-           th:placeholder="${placeholder}"
-           th:attr="
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <input type="text" class="text-input form-width--med ssn-input"
+               th:id="${inputName}"
+               th:name="${inputName}"
+               th:placeholder="${placeholder}"
+               th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-           th:value="${inputData.getOrDefault(inputName, '')}"
-           inputmode="numeric">
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+               th:value="${fieldData.getOrDefault(inputName, '')}"
+               inputmode="numeric">
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/text.html
+++ b/src/main/resources/templates/fragments/inputs/text.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="text"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},

--- a/src/main/resources/templates/fragments/inputs/text.html
+++ b/src/main/resources/templates/fragments/inputs/text.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="text"
-    th:with="
+        th:fragment="text"
+        th:with="
+      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -11,25 +12,25 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <input type="text" class="text-input"
-           th:id="${inputName}"
-           th:name="${inputName}"
-           th:placeholder="${placeholder}"
-           th:attr="
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <input type="text" class="text-input"
+               th:id="${inputName}"
+               th:name="${inputName}"
+               th:placeholder="${placeholder}"
+               th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-           th:value="${inputData.getOrDefault(inputName, '')}">
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+               th:value="${data.getOrDefault(inputName, '')}">
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/text.html
+++ b/src/main/resources/templates/fragments/inputs/text.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="text"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="text"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -12,25 +12,25 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <input type="text" class="text-input"
-               th:id="${inputName}"
-               th:name="${inputName}"
-               th:placeholder="${placeholder}"
-               th:attr="
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <input type="text" class="text-input"
+           th:id="${inputName}"
+           th:name="${inputName}"
+           th:placeholder="${placeholder}"
+           th:attr="
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-               th:value="${fieldData.getOrDefault(inputName, '')}">
-        <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+           th:value="${fieldData.getOrDefault(inputName, '')}">
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/text.html
+++ b/src/main/resources/templates/fragments/inputs/text.html
@@ -4,7 +4,7 @@
 <th:block
         th:fragment="text"
         th:with="
-      data=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -27,7 +27,7 @@
             aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
             aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
             aria-invalid=${hasError}"
-               th:value="${data.getOrDefault(inputName, '')}">
+               th:value="${fieldData.getOrDefault(inputName, '')}">
         <th:block
                 th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </div>

--- a/src/main/resources/templates/fragments/inputs/textArea.html
+++ b/src/main/resources/templates/fragments/inputs/textArea.html
@@ -2,9 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-        th:fragment="textArea"
-        th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+    th:fragment="textArea"
+    th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -14,27 +14,27 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-        <p class="text--help"
-           th:if="${hasHelpText}"
-           th:id="${inputName + '-help-text'}"
-           th:text="${helpText}"></p>
-        <textarea th:fragment="textArea"
-                  type="textarea"
-                  class="textarea spacing-below-0"
-                  th:attr="
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <textarea th:fragment="textArea"
+              type="textarea"
+              class="textarea spacing-below-0"
+              th:attr="
                 aria-describedby=${hasHelpText ? inputName + '-help-message' : ''},
                 aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
                 rows=${rows},
                 maxlength=${maxLength},
                 aria-invalid=${hasError}"
-                  th:id="${inputName}"
-                  th:name="${inputName}">[[${fieldData.getOrDefault(inputName, '')}]]</textarea>
-        <th:block
-                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-    </div>
+              th:id="${inputName}"
+              th:name="${inputName}">[[${fieldData.getOrDefault(inputName, '')}]]</textarea>
+    <th:block
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+  </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/inputs/textArea.html
+++ b/src/main/resources/templates/fragments/inputs/textArea.html
@@ -4,7 +4,6 @@
 <th:block
     th:fragment="textArea"
     th:with="
-      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},

--- a/src/main/resources/templates/fragments/inputs/textArea.html
+++ b/src/main/resources/templates/fragments/inputs/textArea.html
@@ -2,8 +2,9 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block
-    th:fragment="textArea"
-    th:with="
+        th:fragment="textArea"
+        th:with="
+      fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
       hasHelpText=${!#strings.isEmpty(helpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
@@ -13,27 +14,27 @@
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
         (#arrays.length(errorMessages.get(inputName)) > 0) }"
-    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
-  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
-    <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
-    <p class="text--help"
-       th:if="${hasHelpText}"
-       th:id="${inputName + '-help-text'}"
-       th:text="${helpText}"></p>
-    <textarea th:fragment="textArea"
-              type="textarea"
-              class="textarea spacing-below-0"
-              th:attr="
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <textarea th:fragment="textArea"
+                  type="textarea"
+                  class="textarea spacing-below-0"
+                  th:attr="
                 aria-describedby=${hasHelpText ? inputName + '-help-message' : ''},
                 aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
                 rows=${rows},
                 maxlength=${maxLength},
                 aria-invalid=${hasError}"
-              th:id="${inputName}"
-              th:name="${inputName}">[[${inputData.getOrDefault(inputName, '')}]]</textarea>
-    <th:block
-        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
-  </div>
+                  th:id="${inputName}"
+                  th:name="${inputName}">[[${fieldData.getOrDefault(inputName, '')}]]</textarea>
+        <th:block
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    </div>
 </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
+++ b/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
@@ -3,7 +3,7 @@
 <body>
 <th:block th:fragment="addressSelectionScreen(addressInputToCheck, inputName, editAddressURL)"
           th:with="
-          fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
+
           foundValidatedAddress=${fieldData.get(addressInputToCheck + 'StreetAddress1_validated') != null},
           isExactValidationMatch=${submission.submittedAddressMatchesValidatedAddress(addressInputToCheck)}">
   <div class="grid__item spacing-above-35 spacing-below-35">

--- a/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
+++ b/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
@@ -3,63 +3,64 @@
 <body>
 <th:block th:fragment="addressSelectionScreen(addressInputToCheck, inputName, editAddressURL)"
           th:with="
-          foundValidatedAddress=${inputData.get(addressInputToCheck + 'StreetAddress1_validated') != null},
+          fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+          foundValidatedAddress=${fieldData.get(addressInputToCheck + 'StreetAddress1_validated') != null},
           isExactValidationMatch=${submission.submittedAddressMatchesValidatedAddress(addressInputToCheck)}">
-  <div class="grid__item spacing-above-35 spacing-below-35">
-    <p th:text="${isExactValidationMatch}"></p>
-    <h1 class="h2" th:if="${foundValidatedAddress && !isExactValidationMatch}"
-        th:text="#{address-validation.header.check-your-address}"></h1>
-    <h1 class="h2" th:if="${!foundValidatedAddress}"
-        th:text="#{address-validation.header.make-sure-your-address-is-correct}"></h1>
-    <h1 class="h2" th:if="${isExactValidationMatch}"
-        th:text="#{address-validation.confirm}"></h1>
-    <p th:if="${foundValidatedAddress && !isExactValidationMatch}"
-       th:text="#{address-validation.warning.we-updated-the-address-you-entered}"
-       class="notice--warning"></p>
-    <p th:if="${!foundValidatedAddress}"
-       th:text="#{address-validation.warning.we-couldnt-find-your-address}"
-       class="notice--warning"></p>
-  </div>
-  <div class="grid__item address-validation spacing-below-60">
-    <label th:for="validated-address"
-           th:if="${foundValidatedAddress && !isExactValidationMatch}"
-           class="radio-button"
-           id="validated-address-label">
-      <p class="spacing-below-15"
-         th:text="#{address-validation.suggested}"></p>
-      <div th:text="${inputData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
-      <div
-          th:text="${inputData.get(addressInputToCheck + 'City_validated')} + ', ' + ${inputData.get(addressInputToCheck + 'State_validated')}"></div>
-      <div th:text="${inputData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
-      <input type="radio" th:name="${inputName}" id="validated-address"
-             th:value="true"
-             th:checked="true">
-    </label>
-    <label th:for="original-address"
-           class="radio-button"
-           th:classappend="${foundValidatedAddress} ? '' : 'is-selected left-aligned'"
-           id="original-address-label">
-      <p class="spacing-below-15"
-         th:text="#{address-validation.address-entered}"></p>
-      <div th:text="${inputData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-      <div th:text="${inputData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-      <div
-          th:text="${inputData.get(addressInputToCheck + 'City')} + ', ' + ${inputData.get(addressInputToCheck + 'State')}"></div>
-      <div th:text="${inputData.get(addressInputToCheck + 'ZipCode')}"></div>
-      <input type="radio"
-             th:classappend="${!foundValidatedAddress || isExactValidationMatch} ? 'hide-radio-circle' : ''"
-             th:name="${inputName}" id="original-address"
-             th:value="false"
-             th:checked="${!foundValidatedAddress || isExactValidationMatch} ? true : false">
-    </label>
-  </div>
-  <th:block th:if="${foundValidatedAddress && !isExactValidationMatch}">
-    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+    <div class="grid__item spacing-above-35 spacing-below-35">
+        <p th:text="${isExactValidationMatch}"></p>
+        <h1 class="h2" th:if="${foundValidatedAddress && !isExactValidationMatch}"
+            th:text="#{address-validation.header.check-your-address}"></h1>
+        <h1 class="h2" th:if="${!foundValidatedAddress}"
+            th:text="#{address-validation.header.make-sure-your-address-is-correct}"></h1>
+        <h1 class="h2" th:if="${isExactValidationMatch}"
+            th:text="#{address-validation.confirm}"></h1>
+        <p th:if="${foundValidatedAddress && !isExactValidationMatch}"
+           th:text="#{address-validation.warning.we-updated-the-address-you-entered}"
+           class="notice--warning"></p>
+        <p th:if="${!foundValidatedAddress}"
+           th:text="#{address-validation.warning.we-couldnt-find-your-address}"
+           class="notice--warning"></p>
+    </div>
+    <div class="grid__item address-validation spacing-below-60">
+        <label th:for="validated-address"
+               th:if="${foundValidatedAddress && !isExactValidationMatch}"
+               class="radio-button"
+               id="validated-address-label">
+            <p class="spacing-below-15"
+               th:text="#{address-validation.suggested}"></p>
+            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
+            <div
+                    th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
+            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
+            <input type="radio" th:name="${inputName}" id="validated-address"
+                   th:value="true"
+                   th:checked="true">
+        </label>
+        <label th:for="original-address"
+               class="radio-button"
+               th:classappend="${foundValidatedAddress} ? '' : 'is-selected left-aligned'"
+               id="original-address-label">
+            <p class="spacing-below-15"
+               th:text="#{address-validation.address-entered}"></p>
+            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+            <div
+                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+            <input type="radio"
+                   th:classappend="${!foundValidatedAddress || isExactValidationMatch} ? 'hide-radio-circle' : ''"
+                   th:name="${inputName}" id="original-address"
+                   th:value="false"
+                   th:checked="${!foundValidatedAddress || isExactValidationMatch} ? true : false">
+        </label>
+    </div>
+    <th:block th:if="${foundValidatedAddress && !isExactValidationMatch}">
+        <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{general.inputs.continue})}"/>
-  </th:block>
-  <a th:if="${!foundValidatedAddress || isExactValidationMatch}" th:href="${editAddressURL}"
-     class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
-  <th:block th:if="${foundValidatedAddress}" th:replace="~{fragments/inputs/submitButton :: submitButton(
+    </th:block>
+    <a th:if="${!foundValidatedAddress || isExactValidationMatch}" th:href="${editAddressURL}"
+       class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
+    <th:block th:if="${foundValidatedAddress}" th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{address-validation.button.use-this-address}, classes='button')}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
+++ b/src/main/resources/templates/fragments/screens/addressSelectionScreen.html
@@ -3,64 +3,64 @@
 <body>
 <th:block th:fragment="addressSelectionScreen(addressInputToCheck, inputName, editAddressURL)"
           th:with="
-          fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)},
+          fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)},
           foundValidatedAddress=${fieldData.get(addressInputToCheck + 'StreetAddress1_validated') != null},
           isExactValidationMatch=${submission.submittedAddressMatchesValidatedAddress(addressInputToCheck)}">
-    <div class="grid__item spacing-above-35 spacing-below-35">
-        <p th:text="${isExactValidationMatch}"></p>
-        <h1 class="h2" th:if="${foundValidatedAddress && !isExactValidationMatch}"
-            th:text="#{address-validation.header.check-your-address}"></h1>
-        <h1 class="h2" th:if="${!foundValidatedAddress}"
-            th:text="#{address-validation.header.make-sure-your-address-is-correct}"></h1>
-        <h1 class="h2" th:if="${isExactValidationMatch}"
-            th:text="#{address-validation.confirm}"></h1>
-        <p th:if="${foundValidatedAddress && !isExactValidationMatch}"
-           th:text="#{address-validation.warning.we-updated-the-address-you-entered}"
-           class="notice--warning"></p>
-        <p th:if="${!foundValidatedAddress}"
-           th:text="#{address-validation.warning.we-couldnt-find-your-address}"
-           class="notice--warning"></p>
-    </div>
-    <div class="grid__item address-validation spacing-below-60">
-        <label th:for="validated-address"
-               th:if="${foundValidatedAddress && !isExactValidationMatch}"
-               class="radio-button"
-               id="validated-address-label">
-            <p class="spacing-below-15"
-               th:text="#{address-validation.suggested}"></p>
-            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
-            <div
-                    th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
-            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
-            <input type="radio" th:name="${inputName}" id="validated-address"
-                   th:value="true"
-                   th:checked="true">
-        </label>
-        <label th:for="original-address"
-               class="radio-button"
-               th:classappend="${foundValidatedAddress} ? '' : 'is-selected left-aligned'"
-               id="original-address-label">
-            <p class="spacing-below-15"
-               th:text="#{address-validation.address-entered}"></p>
-            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-            <div
-                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
-            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
-            <input type="radio"
-                   th:classappend="${!foundValidatedAddress || isExactValidationMatch} ? 'hide-radio-circle' : ''"
-                   th:name="${inputName}" id="original-address"
-                   th:value="false"
-                   th:checked="${!foundValidatedAddress || isExactValidationMatch} ? true : false">
-        </label>
-    </div>
-    <th:block th:if="${foundValidatedAddress && !isExactValidationMatch}">
-        <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+  <div class="grid__item spacing-above-35 spacing-below-35">
+    <p th:text="${isExactValidationMatch}"></p>
+    <h1 class="h2" th:if="${foundValidatedAddress && !isExactValidationMatch}"
+        th:text="#{address-validation.header.check-your-address}"></h1>
+    <h1 class="h2" th:if="${!foundValidatedAddress}"
+        th:text="#{address-validation.header.make-sure-your-address-is-correct}"></h1>
+    <h1 class="h2" th:if="${isExactValidationMatch}"
+        th:text="#{address-validation.confirm}"></h1>
+    <p th:if="${foundValidatedAddress && !isExactValidationMatch}"
+       th:text="#{address-validation.warning.we-updated-the-address-you-entered}"
+       class="notice--warning"></p>
+    <p th:if="${!foundValidatedAddress}"
+       th:text="#{address-validation.warning.we-couldnt-find-your-address}"
+       class="notice--warning"></p>
+  </div>
+  <div class="grid__item address-validation spacing-below-60">
+    <label th:for="validated-address"
+           th:if="${foundValidatedAddress && !isExactValidationMatch}"
+           class="radio-button"
+           id="validated-address-label">
+      <p class="spacing-below-15"
+         th:text="#{address-validation.suggested}"></p>
+      <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
+      <div
+          th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
+      <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
+      <input type="radio" th:name="${inputName}" id="validated-address"
+             th:value="true"
+             th:checked="true">
+    </label>
+    <label th:for="original-address"
+           class="radio-button"
+           th:classappend="${foundValidatedAddress} ? '' : 'is-selected left-aligned'"
+           id="original-address-label">
+      <p class="spacing-below-15"
+         th:text="#{address-validation.address-entered}"></p>
+      <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+      <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+      <div
+          th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+      <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+      <input type="radio"
+             th:classappend="${!foundValidatedAddress || isExactValidationMatch} ? 'hide-radio-circle' : ''"
+             th:name="${inputName}" id="original-address"
+             th:value="false"
+             th:checked="${!foundValidatedAddress || isExactValidationMatch} ? true : false">
+    </label>
+  </div>
+  <th:block th:if="${foundValidatedAddress && !isExactValidationMatch}">
+    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{general.inputs.continue})}"/>
-    </th:block>
-    <a th:if="${!foundValidatedAddress || isExactValidationMatch}" th:href="${editAddressURL}"
-       class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
-    <th:block th:if="${foundValidatedAddress}" th:replace="~{fragments/inputs/submitButton :: submitButton(
+  </th:block>
+  <a th:if="${!foundValidatedAddress || isExactValidationMatch}" th:href="${editAddressURL}"
+     class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
+  <th:block th:if="${foundValidatedAddress}" th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{address-validation.button.use-this-address}, classes='button')}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
-<th:block th:fragment="addressSuggestionFound(addressInputToCheck, inputName)"
-          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}">
+<th:block th:fragment="addressSuggestionFound(addressInputToCheck, inputName)">
   <div class="grid__item spacing-above-35 spacing-below-35">
     <h1 class="h2"
         th:text="${header != null ? header : #messages.msg('address-validation.check-your-address')}"></h1>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
@@ -1,44 +1,45 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
-<th:block th:fragment="addressSuggestionFound(addressInputToCheck, inputName)">
-  <div class="grid__item spacing-above-35 spacing-below-35">
-    <h1 class="h2"
-        th:text="${header != null ? header : #messages.msg('address-validation.check-your-address')}"></h1>
-    <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-updated-the-address-you-entered')}"
-       class="notice--warning"></p>
-  </div>
-  <div class="grid__item address-validation spacing-below-60">
-    <label th:for="validated-address"
-           class="radio-button"
-           id="validated-address-label">
-      <p class="spacing-below-15"
-         th:text="#{address-validation.suggested}"></p>
-      <div th:text="${inputData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
-      <div
-          th:text="${inputData.get(addressInputToCheck + 'City_validated')} + ', ' + ${inputData.get(addressInputToCheck + 'State_validated')}"></div>
-      <div th:text="${inputData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
-      <input type="radio" th:name="${inputName}" id="validated-address"
-             th:value="true"
-             th:checked="true">
-    </label>
-    <label th:for="original-address"
-           class="radio-button"
-           id="original-address-label">
-      <p class="spacing-below-15"
-         th:text="#{address-validation.address-entered}"></p>
-      <div th:text="${inputData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-      <div th:text="${inputData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-      <div
-          th:text="${inputData.get(addressInputToCheck + 'City')} + ', ' + ${inputData.get(addressInputToCheck + 'State')}"></div>
-      <div th:text="${inputData.get(addressInputToCheck + 'ZipCode')}"></div>
-      <input type="radio"
-             th:name="${inputName}" id="original-address"
-             th:value="false"
-             th:checked="false">
-    </label>
-  </div>
-  <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+<th:block th:fragment="addressSuggestionFound(addressInputToCheck, inputName)"
+          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}">
+    <div class="grid__item spacing-above-35 spacing-below-35">
+        <h1 class="h2"
+            th:text="${header != null ? header : #messages.msg('address-validation.check-your-address')}"></h1>
+        <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-updated-the-address-you-entered')}"
+           class="notice--warning"></p>
+    </div>
+    <div class="grid__item address-validation spacing-below-60">
+        <label th:for="validated-address"
+               class="radio-button"
+               id="validated-address-label">
+            <p class="spacing-below-15"
+               th:text="#{address-validation.suggested}"></p>
+            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
+            <div
+                    th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
+            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
+            <input type="radio" th:name="${inputName}" id="validated-address"
+                   th:value="true"
+                   th:checked="true">
+        </label>
+        <label th:for="original-address"
+               class="radio-button"
+               id="original-address-label">
+            <p class="spacing-below-15"
+               th:text="#{address-validation.address-entered}"></p>
+            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+            <div
+                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+            <input type="radio"
+                   th:name="${inputName}" id="original-address"
+                   th:value="false"
+                   th:checked="false">
+        </label>
+    </div>
+    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{general.inputs.continue})}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionFound.html
@@ -2,44 +2,44 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block th:fragment="addressSuggestionFound(addressInputToCheck, inputName)"
-          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}">
-    <div class="grid__item spacing-above-35 spacing-below-35">
-        <h1 class="h2"
-            th:text="${header != null ? header : #messages.msg('address-validation.check-your-address')}"></h1>
-        <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-updated-the-address-you-entered')}"
-           class="notice--warning"></p>
-    </div>
-    <div class="grid__item address-validation spacing-below-60">
-        <label th:for="validated-address"
-               class="radio-button"
-               id="validated-address-label">
-            <p class="spacing-below-15"
-               th:text="#{address-validation.suggested}"></p>
-            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
-            <div
-                    th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
-            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
-            <input type="radio" th:name="${inputName}" id="validated-address"
-                   th:value="true"
-                   th:checked="true">
-        </label>
-        <label th:for="original-address"
-               class="radio-button"
-               id="original-address-label">
-            <p class="spacing-below-15"
-               th:text="#{address-validation.address-entered}"></p>
-            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-            <div
-                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
-            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
-            <input type="radio"
-                   th:name="${inputName}" id="original-address"
-                   th:value="false"
-                   th:checked="false">
-        </label>
-    </div>
-    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}">
+  <div class="grid__item spacing-above-35 spacing-below-35">
+    <h1 class="h2"
+        th:text="${header != null ? header : #messages.msg('address-validation.check-your-address')}"></h1>
+    <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-updated-the-address-you-entered')}"
+       class="notice--warning"></p>
+  </div>
+  <div class="grid__item address-validation spacing-below-60">
+    <label th:for="validated-address"
+           class="radio-button"
+           id="validated-address-label">
+      <p class="spacing-below-15"
+         th:text="#{address-validation.suggested}"></p>
+      <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1_validated')}"></div>
+      <div
+          th:text="${fieldData.get(addressInputToCheck + 'City_validated')} + ', ' + ${fieldData.get(addressInputToCheck + 'State_validated')}"></div>
+      <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode_validated')}"></div>
+      <input type="radio" th:name="${inputName}" id="validated-address"
+             th:value="true"
+             th:checked="true">
+    </label>
+    <label th:for="original-address"
+           class="radio-button"
+           id="original-address-label">
+      <p class="spacing-below-15"
+         th:text="#{address-validation.address-entered}"></p>
+      <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+      <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+      <div
+          th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+      <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+      <input type="radio"
+             th:name="${inputName}" id="original-address"
+             th:value="false"
+             th:checked="false">
+    </label>
+  </div>
+  <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{general.inputs.continue})}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
@@ -1,34 +1,35 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
-<th:block th:fragment="addressSuggestionNotFound(addressInputToCheck, inputName)">
-  <div class="grid__item spacing-above-35 spacing-below-35">
-    <h1 class="h2"
-        th:text="${header != null ? header : #messages.msg('address-validation.header.make-sure-your-address-is-correct')}"></h1>
-    <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-couldnt-find-your-address')}"
-       class="notice--warning"></p>
-  </div>
-  <div class="grid__item address-validation spacing-below-60">
-    <label th:for="original-address"
-           class="radio-button"
-           id="original-address-label">
-      <p class="spacing-below-15"
-         th:text="#{address-validation.address-entered}"></p>
-      <div th:text="${inputData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-      <div th:text="${inputData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-      <div
-          th:text="${inputData.get(addressInputToCheck + 'City')} + ', ' + ${inputData.get(addressInputToCheck + 'State')}"></div>
-      <div th:text="${inputData.get(addressInputToCheck + 'ZipCode')}"></div>
-      <input type="radio"
-             class="hide-radio-circle"
-             th:name="${inputName}" id="original-address"
-             th:value="false"
-             th:checked="true">
-    </label>
-  </div>
-  <a th:href="${editAddressURL}"
-     class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
-  <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+<th:block th:fragment="addressSuggestionNotFound(addressInputToCheck, inputName)"
+          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}">
+    <div class="grid__item spacing-above-35 spacing-below-35">
+        <h1 class="h2"
+            th:text="${header != null ? header : #messages.msg('address-validation.header.make-sure-your-address-is-correct')}"></h1>
+        <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-couldnt-find-your-address')}"
+           class="notice--warning"></p>
+    </div>
+    <div class="grid__item address-validation spacing-below-60">
+        <label th:for="original-address"
+               class="radio-button"
+               id="original-address-label">
+            <p class="spacing-below-15"
+               th:text="#{address-validation.address-entered}"></p>
+            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+            <div
+                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+            <input type="radio"
+                   class="hide-radio-circle"
+                   th:name="${inputName}" id="original-address"
+                   th:value="false"
+                   th:checked="true">
+        </label>
+    </div>
+    <a th:href="${editAddressURL}"
+       class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
+    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{address-validation.button.use-this-address}, classes='button')}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
@@ -2,34 +2,34 @@
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block th:fragment="addressSuggestionNotFound(addressInputToCheck, inputName)"
-          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(currentSubflowItem, inputData)}">
-    <div class="grid__item spacing-above-35 spacing-below-35">
-        <h1 class="h2"
-            th:text="${header != null ? header : #messages.msg('address-validation.header.make-sure-your-address-is-correct')}"></h1>
-        <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-couldnt-find-your-address')}"
-           class="notice--warning"></p>
-    </div>
-    <div class="grid__item address-validation spacing-below-60">
-        <label th:for="original-address"
-               class="radio-button"
-               id="original-address-label">
-            <p class="spacing-below-15"
-               th:text="#{address-validation.address-entered}"></p>
-            <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
-            <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
-            <div
-                    th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
-            <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
-            <input type="radio"
-                   class="hide-radio-circle"
-                   th:name="${inputName}" id="original-address"
-                   th:value="false"
-                   th:checked="true">
-        </label>
-    </div>
-    <a th:href="${editAddressURL}"
-       class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
-    <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}">
+  <div class="grid__item spacing-above-35 spacing-below-35">
+    <h1 class="h2"
+        th:text="${header != null ? header : #messages.msg('address-validation.header.make-sure-your-address-is-correct')}"></h1>
+    <p th:text="${notice != null ? notice : #messages.msg('address-validation.warning.we-couldnt-find-your-address')}"
+       class="notice--warning"></p>
+  </div>
+  <div class="grid__item address-validation spacing-below-60">
+    <label th:for="original-address"
+           class="radio-button"
+           id="original-address-label">
+      <p class="spacing-below-15"
+         th:text="#{address-validation.address-entered}"></p>
+      <div th:text="${fieldData.get(addressInputToCheck + 'StreetAddress1')}"></div>
+      <div th:text="${fieldData.getOrDefault(addressInputToCheck + 'StreetAddress2', '')}"></div>
+      <div
+          th:text="${fieldData.get(addressInputToCheck + 'City')} + ', ' + ${fieldData.get(addressInputToCheck + 'State')}"></div>
+      <div th:text="${fieldData.get(addressInputToCheck + 'ZipCode')}"></div>
+      <input type="radio"
+             class="hide-radio-circle"
+             th:name="${inputName}" id="original-address"
+             th:value="false"
+             th:checked="true">
+    </label>
+  </div>
+  <a th:href="${editAddressURL}"
+     class="button button--primary" th:text="#{address-validation.button.edit-my-address}"></a>
+  <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
       text=#{address-validation.button.use-this-address}, classes='button')}"/>
 </th:block>
 </body>

--- a/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
+++ b/src/main/resources/templates/fragments/screens/addressSuggestionNotFound.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <body>
-<th:block th:fragment="addressSuggestionNotFound(addressInputToCheck, inputName)"
-          th:with="fieldData=${T(formflow.library.utils.InputUtils).getFieldData(#vars)}">
+<th:block th:fragment="addressSuggestionNotFound(addressInputToCheck, inputName)">
   <div class="grid__item spacing-above-35 spacing-below-35">
     <h1 class="h2"
         th:text="${header != null ? header : #messages.msg('address-validation.header.make-sure-your-address-is-correct')}"></h1>

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -62,7 +62,6 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       subflowItem.put("firstName", "foo bar baz");
 
       submission.setInputData(Map.of("testSubflow", List.of(subflowItem)));
-
       getPageExpectingSuccess("subflowAddItem/aaa-bbb-ccc");
     }
   }

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -13,6 +13,7 @@ import formflow.library.utilities.AbstractMockMvcTest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -35,6 +36,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
     UUID submissionUUID = UUID.randomUUID();
     submission = Submission.builder().id(submissionUUID).urlParams(new HashMap<>()).inputData(new HashMap<>()).build();
     when(submissionRepositoryService.findOrCreate(any())).thenReturn(submission);
+    when(submissionRepositoryService.findById(any())).thenReturn(Optional.of(submission));
     super.setUp();
   }
 
@@ -46,12 +48,13 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       Map<String, String> queryParams = new HashMap<>();
       queryParams.put("lang", "en");
       getWithQueryParam("test", "lang", "en");
-      assert(submission.getUrlParams().equals(queryParams));
+      assert (submission.getUrlParams().equals(queryParams));
     }
   }
 
   @Nested
   public class SubflowParameters {
+
     @Test
     public void modelIncludesCurrentSubflowItem() throws Exception {
       HashMap<String, String> subflowItem = new HashMap<>();
@@ -59,6 +62,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       subflowItem.put("firstName", "foo bar baz");
 
       submission.setInputData(Map.of("testSubflow", List.of(subflowItem)));
+
       getPageExpectingSuccess("subflowAddItem/aaa-bbb-ccc");
     }
   }

--- a/src/test/java/formflow/library/controllers/UploadControllerTest.java
+++ b/src/test/java/formflow/library/controllers/UploadControllerTest.java
@@ -68,6 +68,7 @@ public class UploadControllerTest extends AbstractMockMvcTest {
     doNothing().when(cloudFileRepository).upload(any(), any());
     MockMultipartFile testImage = new MockMultipartFile("file.jpeg", "someImage.jpg",
         MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
+    session.setAttribute("foo", 1);
     session = new MockHttpSession();
 
     mockMvc.perform(MockMvcRequestBuilders.multipart("/file-upload")

--- a/src/test/java/formflow/library/controllers/UploadControllerTest.java
+++ b/src/test/java/formflow/library/controllers/UploadControllerTest.java
@@ -68,7 +68,6 @@ public class UploadControllerTest extends AbstractMockMvcTest {
     doNothing().when(cloudFileRepository).upload(any(), any());
     MockMultipartFile testImage = new MockMultipartFile("file.jpeg", "someImage.jpg",
         MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
-    session.setAttribute("foo", 1);
     session = new MockHttpSession();
 
     mockMvc.perform(MockMvcRequestBuilders.multipart("/file-upload")

--- a/src/test/java/formflow/library/framework/BeforeDisplayActionTest.java
+++ b/src/test/java/formflow/library/framework/BeforeDisplayActionTest.java
@@ -82,9 +82,9 @@ public class BeforeDisplayActionTest extends AbstractMockMvcTest {
 
     // beforeDisplay
     MvcResult result = getPageExpectingSuccess("pageWithSSNInput/" + subflowUuid + "/edit").andReturn();
-    Map<String, String> inputData = (Map<String, String>) result.getModelAndView().getModel().get("inputData");
-    assertThat(inputData.get("ssnInput")).isEqualTo(ssnInput);
-    assertThat(inputData.get("ssnInputEncrypted")).isNull();
+    Map<String, String> subflowItem = (Map<String, String>) result.getModelAndView().getModel().get("currentSubflowItem");
+    assertThat(subflowItem.get("ssnInput")).isEqualTo(ssnInput);
+    assertThat(subflowItem.get("ssnInputEncrypted")).isNull();
     subflowEntry = submission.getSubflowEntryByUuid("householdMembers", subflowUuid);
     assertThat(subflowEntry.get("ssnInputEncrypted")).isNull();
     assertThat(subflowEntry.get("ssnInput")).isEqualTo(ssnInput);

--- a/src/test/java/formflow/library/framework/BeforeDisplayActionTest.java
+++ b/src/test/java/formflow/library/framework/BeforeDisplayActionTest.java
@@ -58,8 +58,9 @@ public class BeforeDisplayActionTest extends AbstractMockMvcTest {
   @Test
   void shouldSaveEncryptedSSNInSubflow() throws Exception {
     String subflowUuid = UUID.randomUUID().toString();
-
+    Map<String, Object> sessionAttrs = new HashMap<>();
     List<Map<String, Object>> subflowList = new ArrayList<>();
+
     subflowList.add(Map.of("uuid", subflowUuid));
     subflowList.add(Map.of("uuid", UUID.randomUUID().toString(),
         "ssnInput", "111-11-1111",
@@ -69,11 +70,12 @@ public class BeforeDisplayActionTest extends AbstractMockMvcTest {
         "iterationIsComplete", true));
 
     submission.getInputData().put("householdMembers", subflowList);
+    sessionAttrs.put("id", submission.getId());
 
     // beforeSave
     String ssnInput = "333-33-3333";
     postToUrlExpectingSuccess("/flow/testFlow/pageWithSSNInput", "/flow/testFlow/subflowReview",
-        Map.of("ssnInput", List.of(ssnInput)), subflowUuid);
+        Map.of("ssnInput", List.of(ssnInput)), subflowUuid, sessionAttrs);
 
     Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("householdMembers",
         subflowUuid);

--- a/src/test/java/formflow/library/framework/BeforeSaveActionTest.java
+++ b/src/test/java/formflow/library/framework/BeforeSaveActionTest.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest(properties = {"form-flow.path=flows-config/test-before-save-action.yaml"})
@@ -60,6 +61,7 @@ public class BeforeSaveActionTest extends AbstractMockMvcTest {
   @Test
   void shouldSaveTotalIncome() throws Exception {
     String subflowUuid = UUID.randomUUID().toString();
+    session.setAttribute("id", submission.getId());
 
     List<Map<String, Object>> subflowList = new ArrayList<>();
 

--- a/src/test/java/formflow/library/framework/BeforeSaveActionTest.java
+++ b/src/test/java/formflow/library/framework/BeforeSaveActionTest.java
@@ -61,8 +61,7 @@ public class BeforeSaveActionTest extends AbstractMockMvcTest {
   @Test
   void shouldSaveTotalIncome() throws Exception {
     String subflowUuid = UUID.randomUUID().toString();
-    session.setAttribute("id", submission.getId());
-
+    Map<String, Object> sessionAttrs = new HashMap<>();
     List<Map<String, Object>> subflowList = new ArrayList<>();
 
     subflowList.add(Map.of("uuid", subflowUuid));
@@ -74,9 +73,10 @@ public class BeforeSaveActionTest extends AbstractMockMvcTest {
         "iterationIsComplete", true));
 
     submission.getInputData().put("income", subflowList);
+    sessionAttrs.put("id", submission.getId());
 
     postToUrlExpectingSuccess("/flow/testFlow/next", "/flow/testFlow/subflowReview",
-        Map.of("textInput", List.of("1000")), subflowUuid);
+        Map.of("textInput", List.of("1000")), subflowUuid, sessionAttrs);
 
     assertThat(submission.getInputData().get("totalIncome")).isEqualTo(6530.0);
   }

--- a/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
+++ b/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
@@ -52,536 +52,532 @@ import static org.springframework.test.web.servlet.setup.SharedHttpSessionConfig
 @ContextConfiguration
 public abstract class AbstractMockMvcTest {
 
-    @MockBean
-    protected Clock clock;
+  @MockBean
+  protected Clock clock;
 
-    @MockBean
-    protected Submission submission;
+  @MockBean
+  protected Submission submission;
 
-    @Autowired
-    private WebApplicationContext webApplicationContext;
+  @Autowired
+  private WebApplicationContext webApplicationContext;
 
-    @Autowired
-    protected MockMvc mockMvc;
+  @Autowired
+  protected MockMvc mockMvc;
 
 
-    protected MockHttpSession session = new MockHttpSession();
+  protected MockHttpSession session = new MockHttpSession();
 
-    @Autowired
-    protected MessageSource messageSource;
+  @Autowired
+  protected MessageSource messageSource;
 
-    @BeforeEach
-    protected void setUp() throws Exception {
-        this.mockMvc = MockMvcBuilders
-                .webAppContextSetup(this.webApplicationContext)
-                .apply(sharedHttpSession()) // use this session across requests
-                .build();
-    }
+  @BeforeEach
+  protected void setUp() throws Exception {
+    this.mockMvc = MockMvcBuilders
+        .webAppContextSetup(this.webApplicationContext)
+        .apply(sharedHttpSession()) // use this session across requests
+        .build();
+  }
 
-    @AfterEach
-    void cleanup() {
-        resetSubmission();
-    }
+  @AfterEach
+  void cleanup() {
+    resetSubmission();
+  }
 
-    protected void postWithQueryParam(String pageName, String queryParam, String value)
-            throws Exception {
-        mockMvc.perform(
-                        post("/pages/" + pageName).with(csrf()).queryParam(queryParam, value))
-                .andExpect(redirectedUrl("/pages/" + pageName + "/navigation"));
-    }
+  protected void postWithQueryParam(String pageName, String queryParam, String value)
+      throws Exception {
+    mockMvc.perform(
+            post("/pages/" + pageName).with(csrf()).queryParam(queryParam, value))
+        .andExpect(redirectedUrl("/pages/" + pageName + "/navigation"));
+  }
 
-    protected ResultActions getWithQueryParam(String pageName, String queryParam, String value)
-            throws Exception {
-        String getUrl = getUrlForPageName(pageName);
-        return mockMvc.perform(get(getUrl).queryParam(queryParam, value))
-                .andExpect(status().isOk());
-    }
+  protected ResultActions getWithQueryParam(String pageName, String queryParam, String value)
+      throws Exception {
+    String getUrl = getUrlForPageName(pageName);
+    return mockMvc.perform(get(getUrl).queryParam(queryParam, value))
+        .andExpect(status().isOk());
+  }
 
-    protected ResultActions getWithQueryParamAndExpectRedirect(String pageName, String queryParam,
-                                                               String value,
-                                                               String expectedRedirectPageName) throws Exception {
-        return mockMvc.perform(get("/pages/" + pageName).queryParam(queryParam, value))
-                .andExpect(redirectedUrl("/pages/" + expectedRedirectPageName));
-    }
+  protected ResultActions getWithQueryParamAndExpectRedirect(String pageName, String queryParam,
+      String value,
+      String expectedRedirectPageName) throws Exception {
+    return mockMvc.perform(get("/pages/" + pageName).queryParam(queryParam, value))
+        .andExpect(redirectedUrl("/pages/" + expectedRedirectPageName));
+  }
 
-    protected void getNavigationPageWithQueryParamAndExpectRedirect(String pageName,
-                                                                    String queryParam, String value,
-                                                                    String expectedPageName) throws Exception {
-        var request = get("/pages/" + pageName + "/navigation")
-                .queryParam(queryParam, value);
-        var navigationPageUrl = mockMvc.perform(request)
-                .andExpect(status().is3xxRedirection())
-                .andReturn()
-                .getResponse()
-                .getRedirectedUrl();
-        String nextPage = followRedirectsForUrl(navigationPageUrl);
-        assertThat(nextPage).isEqualTo("/pages/" + expectedPageName);
-    }
+  protected void getNavigationPageWithQueryParamAndExpectRedirect(String pageName,
+      String queryParam, String value,
+      String expectedPageName) throws Exception {
+    var request = get("/pages/" + pageName + "/navigation")
+        .queryParam(queryParam, value);
+    var navigationPageUrl = mockMvc.perform(request)
+        .andExpect(status().is3xxRedirection())
+        .andReturn()
+        .getResponse()
+        .getRedirectedUrl();
+    String nextPage = followRedirectsForUrl(navigationPageUrl);
+    assertThat(nextPage).isEqualTo("/pages/" + expectedPageName);
+  }
 
-    protected List<File> unzip(ZipInputStream zipStream) {
-        List<File> fileList = new ArrayList<>();
-        try {
-            ZipEntry zEntry;
-            Path destination = Files.createTempDirectory("");
-            while ((zEntry = zipStream.getNextEntry()) != null) {
-                if (!zEntry.isDirectory()) {
-                    File files = new File(String.valueOf(destination), zEntry.getName());
-                    FileOutputStream fout = new FileOutputStream(files);
-                    BufferedOutputStream bufout = new BufferedOutputStream(fout);
-                    byte[] buffer = new byte[1024];
-                    int read;
-                    while ((read = zipStream.read(buffer)) != -1) {
-                        bufout.write(buffer, 0, read);
-                    }
-                    zipStream.closeEntry();//This will delete zip folder after extraction
-                    bufout.close();
-                    fout.close();
-                    fileList.add(files);
-                }
-            }
-            zipStream.close();//This will delete zip folder after extraction
-        } catch (Exception e) {
-            System.out.println("Unzipping failed");
-            e.printStackTrace();
+  protected List<File> unzip(ZipInputStream zipStream) {
+    List<File> fileList = new ArrayList<>();
+    try {
+      ZipEntry zEntry;
+      Path destination = Files.createTempDirectory("");
+      while ((zEntry = zipStream.getNextEntry()) != null) {
+        if (!zEntry.isDirectory()) {
+          File files = new File(String.valueOf(destination), zEntry.getName());
+          FileOutputStream fout = new FileOutputStream(files);
+          BufferedOutputStream bufout = new BufferedOutputStream(fout);
+          byte[] buffer = new byte[1024];
+          int read;
+          while ((read = zipStream.read(buffer)) != -1) {
+            bufout.write(buffer, 0, read);
+          }
+          zipStream.closeEntry();//This will delete zip folder after extraction
+          bufout.close();
+          fout.close();
+          fileList.add(files);
         }
-        return fileList;
+      }
+      zipStream.close();//This will delete zip folder after extraction
+    } catch (Exception e) {
+      System.out.println("Unzipping failed");
+      e.printStackTrace();
     }
+    return fileList;
+  }
 
-    protected ResultActions postExpectingSuccess(String pageName) throws Exception {
-        return postWithoutData(pageName)
-                .andExpect(redirectedUrl(getUrlForPageName(pageName) + "/navigation"));
+  protected ResultActions postExpectingSuccess(String pageName) throws Exception {
+    return postWithoutData(pageName)
+        .andExpect(redirectedUrl(getUrlForPageName(pageName) + "/navigation"));
+  }
+
+  protected ResultActions postStartSubflowExpectingSuccess(String pageName) throws Exception {
+    String postUrl = getUrlForPageName(pageName, "new");
+    return postWithoutData(postUrl).andExpect(redirectedUrl(postUrl + "/navigation"));
+  }
+
+  // Post to a page with an arbitrary number of multi-value inputs
+  protected ResultActions postExpectingSuccess(String pageName, Map<String, List<String>> params)
+      throws Exception {
+    String postUrl = getUrlForPageName(pageName);
+    return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", params);
+  }
+
+  // Post to a page with a single input that only accepts a single value
+  protected ResultActions postExpectingSuccess(String pageName, String inputName, String value)
+      throws Exception {
+    String postUrl = getUrlForPageName(pageName);
+    var params = Map.of(inputName, List.of(value));
+    return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", params);
+  }
+
+  // Post to a page with a single input that accepts multiple values
+  protected ResultActions postExpectingSuccess(String pageName, String inputName,
+      List<String> values) throws Exception {
+    String postUrl = getUrlForPageName(pageName);
+    return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", Map.of(inputName, values));
+  }
+
+  protected ResultActions postToUrlExpectingSuccess(String postUrl, String redirectUrl,
+      Map<String, List<String>> params) throws
+      Exception {
+
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .params(new LinkedMultiValueMap<>(params))
+    ).andExpect(redirectedUrl(redirectUrl));
+  }
+
+  protected ResultActions postToUrlExpectingSuccess(String postUrl, String redirectUrl,
+      Map<String, List<String>> params, String id, Map<String, Object> sessionAttrs) throws
+      Exception {
+    return mockMvc.perform(
+        post(postUrl + '/' + id)
+            .sessionAttrs(sessionAttrs)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .params(new LinkedMultiValueMap<>(params))
+    ).andExpect(redirectedUrl(redirectUrl));
+  }
+
+  protected void postExpectingNextPageElementText(String pageName,
+      String inputName,
+      String value,
+      String elementId,
+      String expectedText) throws Exception {
+    var nextPage = postAndFollowRedirect(pageName, inputName, value);
+    assertThat(nextPage.getElementTextById(elementId)).isEqualTo(expectedText);
+  }
+
+  protected void assertPageHasElementWithId(String pageName, String elementId) throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertThat(page.getElementById(elementId)).isNotNull();
+  }
+
+  protected void assertPageDoesNotHaveElementWithId(String pageName, String elementId)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertThat(page.getElementById(elementId)).isNull();
+  }
+
+  protected void postExpectingNextPageTitle(String pageName,
+      String inputName,
+      String value,
+      String nextPageTitle) throws Exception {
+    var nextPage = postAndFollowRedirect(pageName, inputName, value);
+    assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
+  }
+
+  protected void postExpectingNextPageTitle(String pageName,
+      String inputName,
+      List<String> values,
+      String nextPageTitle) throws Exception {
+    var nextPage = postAndFollowRedirect(pageName, inputName, values);
+    assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
+  }
+
+  protected void postExpectingNextPageTitle(String pageName,
+      Map<String, List<String>> params,
+      String nextPageTitle) throws Exception {
+    var nextPage = postAndFollowRedirect(pageName, params);
+    assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
+  }
+
+  protected void continueExpectingNextPageTitle(String currentPageName, String nextPageTitle)
+      throws Exception {
+    var nextPage = getNextPageAsFormPage(currentPageName);
+    assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
+  }
+
+  protected void postExpectingRedirect(String pageName, String inputName,
+      String value, String expectedNextPageName) throws Exception {
+    postExpectingSuccess(pageName, inputName, value);
+    assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
+  }
+
+  protected void postExpectingRedirect(String pageName, String inputName, List<String> values,
+      String expectedNextPageName) throws Exception {
+    postExpectingSuccess(pageName, inputName, values);
+    assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
+  }
+
+  protected void postExpectingRedirect(String pageName, String expectedNextPageName)
+      throws Exception {
+    postExpectingSuccess(pageName);
+    assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
+  }
+
+  protected void postExpectingRedirect(String pageName, Map<String, List<String>> params,
+      String expectedNextPageName) throws Exception {
+    postExpectingSuccess(pageName, params);
+    assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
+  }
+
+  protected void assertNavigationRedirectsToCorrectNextPage(String pageName,
+      String expectedNextPageName) throws Exception {
+    String nextPage = followRedirectsForPageName(pageName);
+    assertThat(nextPage).isEqualTo("/pages/" + expectedNextPageName);
+  }
+
+  protected void assertNavigationRedirectsToCorrectNextPageWithOption(String pageName,
+      String option,
+      String expectedNextPageName) throws Exception {
+    String nextPage = followRedirectsForPageNameWithOption(pageName,
+        option.equals("false") ? "1" : "0");
+    assertThat(nextPage).isEqualTo("/pages/" + expectedNextPageName);
+  }
+
+  protected ResultActions postExpectingFailure(String pageName, String inputName, String value)
+      throws Exception {
+    String postUrl = getUrlForPageName(pageName);
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .param(inputName, value)
+    ).andExpect(redirectedUrl(postUrl));
+  }
+
+  protected ResultActions postExpectingFailure(String pageName, String inputName,
+      List<String> values) throws Exception {
+    return postExpectingFailure(pageName, fixInputNamesForParams(Map.of(inputName, values)));
+  }
+
+  protected ResultActions postExpectingFailure(String pageName, Map<String, List<String>> params)
+      throws Exception {
+
+    String postUrl = getUrlForPageName(pageName);
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .params(new LinkedMultiValueMap<>(params))
+    ).andExpect(redirectedUrl(postUrl));
+  }
+
+  protected ResultActions postExpectingFailures(String pageName, Map<String, String> params)
+      throws Exception {
+
+    String postUrl = getUrlForPageName(pageName);
+    MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+    params.forEach(multiValueMap::add);
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .params(multiValueMap)
+    ).andExpect(redirectedUrl(postUrl));
+  }
+
+  protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
+      String inputName,
+      String value) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertPageHasInputError(pageName, inputName);
+  }
+
+
+  protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
+      String inputName,
+      String value, String errorMessage) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertPageHasInputError(pageName, inputName, errorMessage);
+  }
+
+  protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
+      String inputName,
+      List<String> value, String errorMessage) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertPageHasInputError(pageName, inputName, errorMessage);
+  }
+
+  protected void postExpectingFailureAndAssertErrorsDisplaysForThatInput(String pageName,
+      String inputName,
+      String value, Integer numOfErrors) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertInputHasErrors(pageName, inputName, numOfErrors);
+  }
+
+  protected void postExpectingFailureAndAssertErrorsDisplayForThatInput(String pageName,
+      String inputName,
+      String value, List<String> errorMessages) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertInputHasErrors(pageName, inputName, errorMessages);
+  }
+
+  protected void postExpectingFailureAndAssertInputErrorMessages(String pageName,
+      Map<String, String> inputParams,
+      Map<String, List<String>> expectedErrorMessages) throws Exception {
+    postExpectingFailures(pageName, inputParams);
+    for (String inputName : inputParams.keySet()) {
+      assertInputHasErrors(pageName, inputName, expectedErrorMessages.get(inputName));
     }
+  }
 
-    protected ResultActions postStartSubflowExpectingSuccess(String pageName) throws Exception {
-        String postUrl = getUrlForPageName(pageName, "new");
-        return postWithoutData(postUrl).andExpect(redirectedUrl(postUrl + "/navigation"));
+  protected void postExpectingFailureAndAssertErrorDisplaysForThatDateInput(String pageName,
+      String inputName,
+      List<String> values) throws Exception {
+    postExpectingFailure(pageName, inputName, values);
+    assertPageHasDateInputError(pageName, inputName);
+  }
+
+
+  protected void postExpectingFailureAndAssertErrorDisplaysOnDifferentInput(String pageName,
+      String inputName,
+      String value,
+      String inputNameWithError) throws Exception {
+    postExpectingFailure(pageName, inputName, value);
+    assertPageHasInputError(pageName, inputNameWithError);
+  }
+
+  protected void postExpectingFailureAndAssertErrorDisplaysOnDifferentInput(String pageName,
+      String inputName,
+      List<String> values,
+      String inputNameWithError) throws Exception {
+    postExpectingFailure(pageName, inputName, values);
+    assertPageHasInputError(pageName, inputNameWithError);
+  }
+
+  @NotNull
+  //TODO Get rid of this maybe?
+  private Map<String, List<String>> fixInputNamesForParams(Map<String, List<String>> params) {
+    return params.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey() + "[]", Map.Entry::getValue));
+  }
+
+  protected ResultActions postWithoutData(String pageName) throws Exception {
+    String postUrl = getUrlForPageName(pageName);
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    );
+  }
+
+  protected String getUrlForPageName(String pageName, String subflow) {
+    return "/flow/testFlow/" + pageName + "/" + subflow;
+
+  }
+
+  protected String getUrlForPageName(String pageName) {
+    return "/flow/testFlow/" + pageName;
+  }
+
+  protected void assertPageHasInputError(String pageName, String inputName) throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertTrue(page.hasInputError(inputName));
+  }
+
+  protected void assertPageHasInputError(String pageName, String inputName, String errorMessage)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertEquals(errorMessage, page.getInputError(inputName).text());
+  }
+
+  protected void assertInputHasErrors(String pageName, String inputName, Integer numOfErrors)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertEquals(numOfErrors, page.getInputErrors(inputName).size());
+  }
+
+  protected void assertInputHasErrors(String pageName, String inputName, List<String> errorMessages)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    // make sure there are errors returned
+    assertFalse(page.getInputErrors(inputName).isEmpty(), "Expected errors on page, but there were none");
+    // assert equal amount
+    assertEquals(errorMessages.size(), page.getInputErrors(inputName).size(),
+        "The page has a different number of errors than expected");
+    // now check if they match the expected ones.
+    assertTrue(errorMessages.containsAll(page.getInputErrors(inputName).stream().map(Element::ownText).toList()),
+        "The error messages expected do match what was returned");
+  }
+
+  protected void assertPageHasDateInputError(String pageName, String inputName) throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertTrue(page.hasDateInputError());
+  }
+
+  protected void assertPageDoesNotHaveInputError(String pageName, String inputName)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertFalse(page.hasInputError(inputName));
+  }
+
+  protected void assertPageHasWarningMessage(String pageName, String warningMessage)
+      throws Exception {
+    var page = new FormScreen(getPage(pageName));
+    assertEquals(page.getWarningMessage(), warningMessage);
+  }
+
+  @NotNull
+  protected ResultActions getPage(String pageName) throws Exception {
+    return mockMvc.perform(get("/flow/testFlow/" + pageName));
+  }
+
+  @NotNull
+  protected ResultActions getPageExpectingSuccess(String pageName) throws Exception {
+    return getPage(pageName).andExpect(status().isOk());
+  }
+
+  /**
+   * Accepts the page you are on and follows the redirects to get the next page
+   *
+   * @param currentPageName the page
+   * @return a form page that can be asserted against
+   */
+  protected FormScreen getNextPageAsFormPage(String currentPageName) throws Exception {
+    String nextPage = followRedirectsForPageName(currentPageName);
+    return new FormScreen(mockMvc.perform(get(nextPage)));
+  }
+
+  @NotNull
+  private String followRedirectsForPageName(String currentPageName) throws Exception {
+    var nextPage = "/flow/testFlow/" + currentPageName + "/navigation";
+    while (Objects.requireNonNull(nextPage).contains("/navigation")) {
+      // follow redirects
+      nextPage = mockMvc.perform(get(nextPage))
+          .andExpect(status().is3xxRedirection()).andReturn()
+          .getResponse()
+          .getRedirectedUrl();
     }
+    return nextPage;
+  }
 
-    // Post to a page with an arbitrary number of multi-value inputs
-    protected ResultActions postExpectingSuccess(String pageName, Map<String, List<String>> params)
-            throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", params);
+  private String followRedirectsForUrl(String currentPageUrl) throws Exception {
+    var nextPage = currentPageUrl;
+    while (Objects.requireNonNull(nextPage).contains("/navigation")) {
+      // follow redirects
+      nextPage = mockMvc.perform(get(nextPage))
+          .andExpect(status().is3xxRedirection()).andReturn()
+          .getResponse()
+          .getRedirectedUrl();
     }
+    return nextPage;
+  }
 
-    protected ResultActions postExpectingSuccess(String pageName, String id, Map<String, List<String>> params)
-            throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", params, id);
+  protected FormScreen postAndFollowRedirect(String pageName, String inputName, String value) throws
+      Exception {
+    postExpectingSuccess(pageName, inputName, value);
+    return getNextPageAsFormPage(pageName);
+  }
+
+  protected FormScreen postAndFollowRedirect(String pageName, Map<String, List<String>> params)
+      throws
+      Exception {
+    postExpectingSuccess(pageName, params);
+    return getNextPageAsFormPage(pageName);
+  }
+
+  protected FormScreen postAndFollowRedirect(String pageName) throws
+      Exception {
+    postExpectingSuccess(pageName);
+    return getNextPageAsFormPage(pageName);
+  }
+
+  protected FormScreen postAndFollowRedirect(String pageName, String inputName,
+      List<String> values) throws
+      Exception {
+    postExpectingSuccess(pageName, inputName, values);
+    return getNextPageAsFormPage(pageName);
+  }
+
+  protected void getPageAndExpectRedirect(String getPageName, String redirectPageName)
+      throws Exception {
+    getPage(getPageName).andExpect(redirectedUrl("/pages/" + redirectPageName));
+  }
+
+  protected FormScreen goBackTo(String getPageName)
+      throws Exception {
+    return new FormScreen(getPage(getPageName));
+  }
+
+  protected void assertCorrectPageTitle(String pageName, String pageTitle) throws Exception {
+    assertThat(new FormScreen(getPage(pageName)).getTitle()).isEqualTo(pageTitle);
+  }
+
+  protected void clickContinueOnInfoPage(String pageName, String continueButtonText,
+      String expectedNextPageName) throws Exception {
+    FormScreen page = new FormScreen(getPage(pageName));
+    page.assertLinkWithTextHasCorrectUrl(continueButtonText,
+        "/pages/%s/navigation?option=0".formatted(pageName));
+    assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
+  }
+
+  @NotNull
+  private String followRedirectsForPageNameWithOption(String currentPageName, String option)
+      throws Exception {
+    var nextPage = "/pages/" + currentPageName + "/navigation?option=" + option;
+    while (Objects.requireNonNull(nextPage).contains("/navigation")) {
+      // follow redirects
+      nextPage = mockMvc.perform(get(nextPage))
+          .andExpect(status().is3xxRedirection()).andReturn()
+          .getResponse()
+          .getRedirectedUrl();
     }
-
-    // Post to a page with a single input that only accepts a single value
-    protected ResultActions postExpectingSuccess(String pageName, String inputName, String value)
-            throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        var params = Map.of(inputName, List.of(value));
-        return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", params);
-    }
-
-    // Post to a page with a single input that accepts multiple values
-    protected ResultActions postExpectingSuccess(String pageName, String inputName,
-                                                 List<String> values) throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        return postToUrlExpectingSuccess(postUrl, postUrl + "/navigation", Map.of(inputName, values));
-    }
-
-    protected ResultActions postToUrlExpectingSuccess(String postUrl, String redirectUrl,
-                                                      Map<String, List<String>> params) throws
-            Exception {
-        return mockMvc.perform(
-                post(postUrl)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .params(new LinkedMultiValueMap<>(params))
-        ).andExpect(redirectedUrl(redirectUrl));
-    }
-
-    protected ResultActions postToUrlExpectingSuccess(String postUrl, String redirectUrl,
-                                                      Map<String, List<String>> params, String id) throws
-            Exception {
-        return mockMvc.perform(
-                post(postUrl + '/' + id)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .params(new LinkedMultiValueMap<>(params))
-        ).andExpect(redirectedUrl(redirectUrl));
-    }
-
-    protected void postExpectingNextPageElementText(String pageName,
-                                                    String inputName,
-                                                    String value,
-                                                    String elementId,
-                                                    String expectedText) throws Exception {
-        var nextPage = postAndFollowRedirect(pageName, inputName, value);
-        assertThat(nextPage.getElementTextById(elementId)).isEqualTo(expectedText);
-    }
-
-    protected void assertPageHasElementWithId(String pageName, String elementId) throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertThat(page.getElementById(elementId)).isNotNull();
-    }
-
-    protected void assertPageDoesNotHaveElementWithId(String pageName, String elementId)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertThat(page.getElementById(elementId)).isNull();
-    }
-
-    protected void postExpectingNextPageTitle(String pageName,
-                                              String inputName,
-                                              String value,
-                                              String nextPageTitle) throws Exception {
-        var nextPage = postAndFollowRedirect(pageName, inputName, value);
-        assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
-    }
-
-    protected void postExpectingNextPageTitle(String pageName,
-                                              String inputName,
-                                              List<String> values,
-                                              String nextPageTitle) throws Exception {
-        var nextPage = postAndFollowRedirect(pageName, inputName, values);
-        assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
-    }
-
-    protected void postExpectingNextPageTitle(String pageName,
-                                              Map<String, List<String>> params,
-                                              String nextPageTitle) throws Exception {
-        var nextPage = postAndFollowRedirect(pageName, params);
-        assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
-    }
-
-    protected void continueExpectingNextPageTitle(String currentPageName, String nextPageTitle)
-            throws Exception {
-        var nextPage = getNextPageAsFormPage(currentPageName);
-        assertThat(nextPage.getTitle()).isEqualTo(nextPageTitle);
-    }
-
-    protected void postExpectingRedirect(String pageName, String inputName,
-                                         String value, String expectedNextPageName) throws Exception {
-        postExpectingSuccess(pageName, inputName, value);
-        assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
-    }
-
-    protected void postExpectingRedirect(String pageName, String inputName, List<String> values,
-                                         String expectedNextPageName) throws Exception {
-        postExpectingSuccess(pageName, inputName, values);
-        assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
-    }
-
-    protected void postExpectingRedirect(String pageName, String expectedNextPageName)
-            throws Exception {
-        postExpectingSuccess(pageName);
-        assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
-    }
-
-    protected void postExpectingRedirect(String pageName, Map<String, List<String>> params,
-                                         String expectedNextPageName) throws Exception {
-        postExpectingSuccess(pageName, params);
-        assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
-    }
-
-    protected void assertNavigationRedirectsToCorrectNextPage(String pageName,
-                                                              String expectedNextPageName) throws Exception {
-        String nextPage = followRedirectsForPageName(pageName);
-        assertThat(nextPage).isEqualTo("/pages/" + expectedNextPageName);
-    }
-
-    protected void assertNavigationRedirectsToCorrectNextPageWithOption(String pageName,
-                                                                        String option,
-                                                                        String expectedNextPageName) throws Exception {
-        String nextPage = followRedirectsForPageNameWithOption(pageName,
-                option.equals("false") ? "1" : "0");
-        assertThat(nextPage).isEqualTo("/pages/" + expectedNextPageName);
-    }
-
-    protected ResultActions postExpectingFailure(String pageName, String inputName, String value)
-            throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        return mockMvc.perform(
-                post(postUrl)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .param(inputName, value)
-        ).andExpect(redirectedUrl(postUrl));
-    }
-
-    protected ResultActions postExpectingFailure(String pageName, String inputName,
-                                                 List<String> values) throws Exception {
-        return postExpectingFailure(pageName, fixInputNamesForParams(Map.of(inputName, values)));
-    }
-
-    protected ResultActions postExpectingFailure(String pageName, Map<String, List<String>> params)
-            throws Exception {
-
-        String postUrl = getUrlForPageName(pageName);
-        return mockMvc.perform(
-                post(postUrl)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .params(new LinkedMultiValueMap<>(params))
-        ).andExpect(redirectedUrl(postUrl));
-    }
-
-    protected ResultActions postExpectingFailures(String pageName, Map<String, String> params)
-            throws Exception {
-
-        String postUrl = getUrlForPageName(pageName);
-        MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
-        params.forEach(multiValueMap::add);
-        return mockMvc.perform(
-                post(postUrl)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .params(multiValueMap)
-        ).andExpect(redirectedUrl(postUrl));
-    }
-
-    protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
-                                                                          String inputName,
-                                                                          String value) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertPageHasInputError(pageName, inputName);
-    }
-
-
-    protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
-                                                                          String inputName,
-                                                                          String value, String errorMessage) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertPageHasInputError(pageName, inputName, errorMessage);
-    }
-
-    protected void postExpectingFailureAndAssertErrorDisplaysForThatInput(String pageName,
-                                                                          String inputName,
-                                                                          List<String> value, String errorMessage) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertPageHasInputError(pageName, inputName, errorMessage);
-    }
-
-    protected void postExpectingFailureAndAssertErrorsDisplaysForThatInput(String pageName,
-                                                                           String inputName,
-                                                                           String value, Integer numOfErrors) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertInputHasErrors(pageName, inputName, numOfErrors);
-    }
-
-    protected void postExpectingFailureAndAssertErrorsDisplayForThatInput(String pageName,
-                                                                          String inputName,
-                                                                          String value, List<String> errorMessages) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertInputHasErrors(pageName, inputName, errorMessages);
-    }
-
-    protected void postExpectingFailureAndAssertInputErrorMessages(String pageName,
-                                                                   Map<String, String> inputParams,
-                                                                   Map<String, List<String>> expectedErrorMessages) throws Exception {
-        postExpectingFailures(pageName, inputParams);
-        for (String inputName : inputParams.keySet()) {
-            assertInputHasErrors(pageName, inputName, expectedErrorMessages.get(inputName));
-        }
-    }
-
-    protected void postExpectingFailureAndAssertErrorDisplaysForThatDateInput(String pageName,
-                                                                              String inputName,
-                                                                              List<String> values) throws Exception {
-        postExpectingFailure(pageName, inputName, values);
-        assertPageHasDateInputError(pageName, inputName);
-    }
-
-
-    protected void postExpectingFailureAndAssertErrorDisplaysOnDifferentInput(String pageName,
-                                                                              String inputName,
-                                                                              String value,
-                                                                              String inputNameWithError) throws Exception {
-        postExpectingFailure(pageName, inputName, value);
-        assertPageHasInputError(pageName, inputNameWithError);
-    }
-
-    protected void postExpectingFailureAndAssertErrorDisplaysOnDifferentInput(String pageName,
-                                                                              String inputName,
-                                                                              List<String> values,
-                                                                              String inputNameWithError) throws Exception {
-        postExpectingFailure(pageName, inputName, values);
-        assertPageHasInputError(pageName, inputNameWithError);
-    }
-
-    @NotNull
-    //TODO Get rid of this maybe?
-    private Map<String, List<String>> fixInputNamesForParams(Map<String, List<String>> params) {
-        return params.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey() + "[]", Map.Entry::getValue));
-    }
-
-    protected ResultActions postWithoutData(String pageName) throws Exception {
-        String postUrl = getUrlForPageName(pageName);
-        return mockMvc.perform(
-                post(postUrl)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-        );
-    }
-
-    protected String getUrlForPageName(String pageName, String subflow) {
-        return "/flow/testFlow/" + pageName + "/" + subflow;
-
-    }
-
-    protected String getUrlForPageName(String pageName) {
-        return "/flow/testFlow/" + pageName;
-    }
-
-    protected void assertPageHasInputError(String pageName, String inputName) throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertTrue(page.hasInputError(inputName));
-    }
-
-    protected void assertPageHasInputError(String pageName, String inputName, String errorMessage)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertEquals(errorMessage, page.getInputError(inputName).text());
-    }
-
-    protected void assertInputHasErrors(String pageName, String inputName, Integer numOfErrors)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertEquals(numOfErrors, page.getInputErrors(inputName).size());
-    }
-
-    protected void assertInputHasErrors(String pageName, String inputName, List<String> errorMessages)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        // make sure there are errors returned
-        assertFalse(page.getInputErrors(inputName).isEmpty(), "Expected errors on page, but there were none");
-        // assert equal amount
-        assertEquals(errorMessages.size(), page.getInputErrors(inputName).size(),
-                "The page has a different number of errors than expected");
-        // now check if they match the expected ones.
-        assertTrue(errorMessages.containsAll(page.getInputErrors(inputName).stream().map(Element::ownText).toList()),
-                "The error messages expected do match what was returned");
-    }
-
-    protected void assertPageHasDateInputError(String pageName, String inputName) throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertTrue(page.hasDateInputError());
-    }
-
-    protected void assertPageDoesNotHaveInputError(String pageName, String inputName)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertFalse(page.hasInputError(inputName));
-    }
-
-    protected void assertPageHasWarningMessage(String pageName, String warningMessage)
-            throws Exception {
-        var page = new FormScreen(getPage(pageName));
-        assertEquals(page.getWarningMessage(), warningMessage);
-    }
-
-    @NotNull
-    protected ResultActions getPage(String pageName) throws Exception {
-        return mockMvc.perform(get("/flow/testFlow/" + pageName));
-    }
-
-    @NotNull
-    protected ResultActions getPageExpectingSuccess(String pageName) throws Exception {
-        return getPage(pageName).andExpect(status().isOk());
-    }
-
-    /**
-     * Accepts the page you are on and follows the redirects to get the next page
-     *
-     * @param currentPageName the page
-     * @return a form page that can be asserted against
-     */
-    protected FormScreen getNextPageAsFormPage(String currentPageName) throws Exception {
-        String nextPage = followRedirectsForPageName(currentPageName);
-        return new FormScreen(mockMvc.perform(get(nextPage)));
-    }
-
-    @NotNull
-    private String followRedirectsForPageName(String currentPageName) throws Exception {
-        var nextPage = "/flow/testFlow/" + currentPageName + "/navigation";
-        while (Objects.requireNonNull(nextPage).contains("/navigation")) {
-            // follow redirects
-            nextPage = mockMvc.perform(get(nextPage))
-                    .andExpect(status().is3xxRedirection()).andReturn()
-                    .getResponse()
-                    .getRedirectedUrl();
-        }
-        return nextPage;
-    }
-
-    private String followRedirectsForUrl(String currentPageUrl) throws Exception {
-        var nextPage = currentPageUrl;
-        while (Objects.requireNonNull(nextPage).contains("/navigation")) {
-            // follow redirects
-            nextPage = mockMvc.perform(get(nextPage))
-                    .andExpect(status().is3xxRedirection()).andReturn()
-                    .getResponse()
-                    .getRedirectedUrl();
-        }
-        return nextPage;
-    }
-
-    protected FormScreen postAndFollowRedirect(String pageName, String inputName, String value) throws
-            Exception {
-        postExpectingSuccess(pageName, inputName, value);
-        return getNextPageAsFormPage(pageName);
-    }
-
-    protected FormScreen postAndFollowRedirect(String pageName, Map<String, List<String>> params)
-            throws
-            Exception {
-        postExpectingSuccess(pageName, params);
-        return getNextPageAsFormPage(pageName);
-    }
-
-    protected FormScreen postAndFollowRedirect(String pageName) throws
-            Exception {
-        postExpectingSuccess(pageName);
-        return getNextPageAsFormPage(pageName);
-    }
-
-    protected FormScreen postAndFollowRedirect(String pageName, String inputName,
-                                               List<String> values) throws
-            Exception {
-        postExpectingSuccess(pageName, inputName, values);
-        return getNextPageAsFormPage(pageName);
-    }
-
-    protected void getPageAndExpectRedirect(String getPageName, String redirectPageName)
-            throws Exception {
-        getPage(getPageName).andExpect(redirectedUrl("/pages/" + redirectPageName));
-    }
-
-    protected FormScreen goBackTo(String getPageName)
-            throws Exception {
-        return new FormScreen(getPage(getPageName));
-    }
-
-    protected void assertCorrectPageTitle(String pageName, String pageTitle) throws Exception {
-        assertThat(new FormScreen(getPage(pageName)).getTitle()).isEqualTo(pageTitle);
-    }
-
-    protected void clickContinueOnInfoPage(String pageName, String continueButtonText,
-                                           String expectedNextPageName) throws Exception {
-        FormScreen page = new FormScreen(getPage(pageName));
-        page.assertLinkWithTextHasCorrectUrl(continueButtonText,
-                "/pages/%s/navigation?option=0".formatted(pageName));
-        assertNavigationRedirectsToCorrectNextPage(pageName, expectedNextPageName);
-    }
-
-    @NotNull
-    private String followRedirectsForPageNameWithOption(String currentPageName, String option)
-            throws Exception {
-        var nextPage = "/pages/" + currentPageName + "/navigation?option=" + option;
-        while (Objects.requireNonNull(nextPage).contains("/navigation")) {
-            // follow redirects
-            nextPage = mockMvc.perform(get(nextPage))
-                    .andExpect(status().is3xxRedirection()).andReturn()
-                    .getResponse()
-                    .getRedirectedUrl();
-        }
-        return nextPage;
-    }
+    return nextPage;
+  }
 }


### PR DESCRIPTION
Helps to address: https://www.pivotaltracker.com/story/show/183082612

Revamps the code so that going back a page in a browser works for subflows that are greater that one page. 

This solidifies the use of "currentSubflowItem" in the Model to represent the current subflow's data.  `inputData`, in the Model, sometimes represented iteration data and sometimes the full input data.  Now it will always be all the input data and doesn't change meaning. 

