### PR TITLE
Fixes a circular dependecy in the subflow preparer

### DIFF
--- a/src/main/java/formflow/library/pdf/SubflowFieldPreparer.java
+++ b/src/main/java/formflow/library/pdf/SubflowFieldPreparer.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
@@ -65,6 +66,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SubflowFieldPreparer implements DefaultSubmissionFieldPreparer {
 
+  @Lazy
   @Autowired
   ActionManager actionManager;
 

--- a/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
+++ b/src/main/java/formflow/library/pdf/SubmissionFieldPreparers.java
@@ -19,16 +19,14 @@ public class SubmissionFieldPreparers {
   private final List<SubmissionFieldPreparer> customPreparers;
 
   private final PdfMapConfiguration pdfMapConfiguration;
-  private final ActionManager actionManager;
 
 
   public SubmissionFieldPreparers(List<DefaultSubmissionFieldPreparer> defaultPreparers,
       List<SubmissionFieldPreparer> customPreparers,
-      PdfMapConfiguration pdfMapConfiguration, ActionManager actionManager) {
+      PdfMapConfiguration pdfMapConfiguration) {
     this.defaultPreparers = defaultPreparers;
     this.customPreparers = customPreparers;
     this.pdfMapConfiguration = pdfMapConfiguration;
-    this.actionManager = actionManager;
   }
 
   /**

--- a/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SingleFieldPreparersTest.java
@@ -20,10 +20,6 @@ class SingleFieldPreparersTest {
 
   private Submission testSubmission;
 
-  @Autowired
-  private ActionManager actionManager;
-
-
   @BeforeEach
   void setUp() {
     testSubmission = Submission.builder()
@@ -44,7 +40,7 @@ class SingleFieldPreparersTest {
     DefaultSubmissionFieldPreparer failingPreparer = mock(DefaultSubmissionFieldPreparer.class);
     PdfMapConfiguration pdfMapConfiguration = mock(PdfMapConfiguration.class);
     SubmissionFieldPreparers submissionFieldPreparers = new SubmissionFieldPreparers(
-        List.of(failingPreparer, successfulPreparer), List.of(), pdfMapConfiguration, actionManager);
+        List.of(failingPreparer, successfulPreparer), List.of(), pdfMapConfiguration);
     Date date = DateTime.parse("2020-09-02").toDate();
     PdfMap pdfMap = new PdfMap();
 

--- a/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
+++ b/src/test/java/formflow/library/pdf/SubmissionFieldPreparersTest.java
@@ -49,7 +49,7 @@ class SubmissionFieldPreparersTest {
     SubmissionFieldPreparers submissionFieldPreparers = new SubmissionFieldPreparers(
         List.of(defaultSingleFieldPreparer, defaultCheckboxFieldPreparer, defaultDatabaseFieldPreparer,
             defaultSubflowFieldPreparer),
-        List.of(testCustomPreparer), pdfMapConfiguration, new ActionManager(List.of()));
+        List.of(testCustomPreparer), pdfMapConfiguration);
 
     submission = Submission.builder().flow("flow1")
         .inputData(


### PR DESCRIPTION
Since we are working to add sending an email via an action in the Starter App, we accidentally created a circular dependency.

The action was being created by Spring at the start of the app, and it uses the 
 * PdfService which creates -> 
 * PdfGenerator which creates ->
 * SubmissionFieldPreparers which creates ->
 * SubflowActionPreparer which tries to use -> 
 * ActionManager
 
But the ActionManager was not created yet, as all the actions need to be created first to hand to it. 

We made the ActionManager in the SubflowFieldPreparer lazy load and that helped the issue go away. Long term we are not sure that this is the way to fix the issue.  

Co-Authored-By: Chibuisi Enyia; cenyia@codeforamerica.org
Co-Authored-By: Alex Gonzalez; agonzalez@codeforamerica.org

