### PR TITLE
Changes handleAfterSaveAction to take updated object

### DIFF
--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -198,7 +198,9 @@ public class ScreenController extends FormFlowController {
     actionManager.handleBeforeSaveAction(currentScreen, submission);
     saveToRepository(submission);
     httpSession.setAttribute("id", submission.getId());
-    actionManager.handleAfterSaveAction(currentScreen, submission);
+    // get updated object, in case dates changed via, etc
+    Submission savedSubmission = submissionRepositoryService.findById(submission.getId()).get();
+    actionManager.handleAfterSaveAction(currentScreen, savedSubmission);
 
     return new ModelAndView(String.format("redirect:/flow/%s/%s/navigation", flow, screen));
   }
@@ -336,7 +338,9 @@ public class ScreenController extends FormFlowController {
     actionManager.handleBeforeSaveAction(currentScreen, submission, iterationUuid);
     saveToRepository(submission, subflowName);
     httpSession.setAttribute("id", submission.getId());
-    actionManager.handleAfterSaveAction(currentScreen, submission, iterationUuid);
+    // get updated submission, in case dates changed, etc
+    Submission savedSubmission = submissionRepositoryService.findById(submission.getId()).get();
+    actionManager.handleAfterSaveAction(currentScreen, savedSubmission, iterationUuid);
 
     String nextScreen = getNextScreenName(httpSession, currentScreen, iterationUuid);
     String viewString = isNextScreenInSubflow(flow, httpSession, currentScreen, iterationUuid) ?


### PR DESCRIPTION
After save was taking the same submission as the before save was taking. It may not have had all the correct state change that happens with a save.  This PR has it fetch the potentially newly update submission and use that in the aftersave instead. 

