### PR TITLE
Fix state on HttpSessions, to handle being in the db.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'com.mailgun:mailgun-java:1.0.8'
     implementation 'com.google.crypto.tink:tink:1.9.0'
+    implementation 'org.springframework.session:spring-session-jdbc'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/formflow/library/UploadController.java
+++ b/src/main/java/formflow/library/UploadController.java
@@ -102,9 +102,6 @@ public class UploadController extends FormFlowController {
 
       if (dzFilesMap == null) {
         fileInfo = UserFile.createFileInfo(uploadedFile, thumbDataUrl);
-        HashMap<String, HashMap<UUID, HashMap<String, String>>> dropzoneInstanceMap = new HashMap<>();
-        dropzoneInstanceMap.put(inputName, userFileMap);
-        httpSession.setAttribute("userFiles", dropzoneInstanceMap);
       } else {
         if (dzFilesMap.containsKey(inputName)) {
           // User files exists, and it already has a key for this dropzone instance
@@ -112,12 +109,15 @@ public class UploadController extends FormFlowController {
           fileInfo = UserFile.createFileInfo(uploadedFile, thumbDataUrl);
         } else {
           // User files exists, but it doesn't have the dropzone instance yet
-          userFileMap = new HashMap<>();
           fileInfo = UserFile.createFileInfo(uploadedFile, thumbDataUrl);
           dzFilesMap.put(inputName, userFileMap);
         }
       }
       userFileMap.put(newFileId, fileInfo);
+
+      HashMap<String, HashMap<UUID, HashMap<String, String>>> dropzoneInstanceMap = new HashMap<>();
+      dropzoneInstanceMap.put(inputName, userFileMap);
+      httpSession.setAttribute("userFiles", dropzoneInstanceMap);
 
       return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.TEXT_PLAIN).body(newFileId.toString());
     } catch (Exception e) {
@@ -170,6 +170,10 @@ public class UploadController extends FormFlowController {
       if (userFileMap.isEmpty()) {
         dzFilesMap.remove(dropZoneInstanceName);
       }
+
+      HashMap<String, HashMap<UUID, HashMap<String, String>>> dropzoneInstanceMap = new HashMap<>();
+      dropzoneInstanceMap.put(dropZoneInstanceName, userFileMap);
+      httpSession.setAttribute("userFiles", dropzoneInstanceMap);
 
       return new RedirectView(returnPath);
     } catch (Exception e) {

--- a/src/main/resources/application-form-flow-library.yaml
+++ b/src/main/resources/application-form-flow-library.yaml
@@ -5,3 +5,10 @@ spring:
   messages:
     encoding: ISO-8859-1
     basename: messages, messages-form-flow
+  session:
+    store-type: jdbc
+    timeout: 72h
+    jdbc:
+      initialize-schema: always
+  jpa:
+    open-in-view: false

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -40,3 +40,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+  session:
+    store-type: jdbc
+    timeout: 72h
+    jdbc:
+      initialize-schema: always


### PR DESCRIPTION
We had been editing things in the HttpSession by object reference. 
With sessions in the db, we have to be more careful about state because the objects are now serialized to the db and cannot be updated by object reference anymore.