### PR TITLE
Change styles to make translate button align with HC button--small

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
@@ -650,26 +650,20 @@ body,
 /* Language Selector */
 
 .language-selector button {
-  padding: 5px 10px;
   margin-bottom: 0;
   margin-right: 0;
   display: flex;
   align-items: center;
   position: relative;
-  background-color: white;
-  border: none;
-  font-size: 16px;
-  color: black;
-  border-radius: 5px;
-  line-height: 1;
   box-shadow: none;
+  border: none;
 }
 
 .language-selector button > span {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  line-height: 1.3;
+  line-height: 1;
 }
 
 .language-selector .icon {
@@ -685,11 +679,11 @@ body,
 }
 
 .language-selector button strong {
-  font-size: 16px;
+  font-size: 1.4rem;
 }
 
 .language-selector .small-text {
-  font-size: 11px;
+  font-size: 1.1rem;
   font-weight: 500;
 }
 

--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
@@ -678,7 +678,7 @@ body,
   }
 }
 
-.language-selector button strong {
+.language-selector .large-text {
   font-size: 1.4rem;
 }
 

--- a/src/main/resources/templates/fragments/languageSelector.html
+++ b/src/main/resources/templates/fragments/languageSelector.html
@@ -17,7 +17,7 @@
           aria-controls="language-menu-dropdown">
     <i class="icon icon-translate" aria-hidden="true"></i>
     <span>
-      <strong th:text="#{language-preferences.button}"></strong>
+      <span class="large-text" th:text="#{language-preferences.button}"></span>
       <span class="small-text"
             th:text="${#messages.msgOrNull('language-preferences.preview.second') == ''}
             ? #{language-preferences.preview.first}

--- a/src/main/resources/templates/fragments/languageSelector.html
+++ b/src/main/resources/templates/fragments/languageSelector.html
@@ -11,7 +11,7 @@
 ">
   <button type="button"
           id="language-menu"
-          class="button translate-button"
+          class="button button--small translate-button"
           th:classappend="${useLinksForDesktopView ? 'use-links-for-desktop' : ''}"
           aria-haspopup="true"
           aria-controls="language-menu-dropdown">


### PR DESCRIPTION
[#185206184](https://www.pivotaltracker.com/story/show/185206184)

Made these changes while pairing with Devon.

Goal: make the height match the [button small example in HoneyCrisp](https://honeycrisp.herokuapp.com/cfa/styleguide#atoms-buttons)