### PR TITLE
Adds a unit test for testing that subflow validation errors on input fields

### DIFF
--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -319,8 +319,15 @@ public class ScreenController extends FormFlowController {
       }
     } else {
       if (isNewIteration) {
+        Map<String, Object> inputData = new HashMap<>();
+        ArrayList<Map<String, Object>> subflow = new ArrayList<>();
+
+        formSubmission.getFormData().put("uuid", iterationUuid);
+        subflow.add(formSubmission.getFormData());
+        inputData.put(subflowName, subflow);
+
         submission.setFlow(flow);
-        submission.setInputData(formSubmission.getFormData());
+        submission.setInputData(inputData);
       } else {
         // We are not in a current session, so this implies we are on the first page
         // of a flow. If it's not a new iteration, then where _are_ we?

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -229,9 +229,6 @@ public class ScreenController extends FormFlowController {
     var currentScreen = getScreenConfig(flow, screen);
     actionManager.handleBeforeDisplayAction(currentScreen, submission, uuid);
     Map<String, Object> model = createModel(flow, screen, httpSession, submission, uuid);
-    // subflow data will be already set in the "fieldData" field.  We keep "currentSubflowItem" for
-    // backwards compatability at this point
-    model.put("currentSubflowItem", model.get("fieldData"));
     model.put("formAction", String.format("/flow/%s/%s/%s", flow, screen, uuid));
     return new ModelAndView(String.format("%s/%s", flow, screen), model);
   }
@@ -626,6 +623,8 @@ public class ScreenController extends FormFlowController {
         // this is a new subflow iteration, we have submission data, so share that
         model.put("fieldData", httpSession.getAttribute("formDataSubmission"));
       }
+      // We keep "currentSubflowItem" for backwards compatability at this point
+      model.put("currentSubflowItem", model.get("fieldData"));
     }
 
     return model;

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -14,13 +14,11 @@ import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
 import formflow.library.utilities.AbstractMockMvcTest;
 import formflow.library.utilities.FormScreen;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.hibernate.validator.constraints.URL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,6 +34,8 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
 
   @MockBean
   private SubmissionRepositoryService submissionRepositoryService;
+
+  public final String uuidPatternString = "{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}}";
 
   @Override
   @BeforeEach
@@ -123,7 +123,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
   }
 
   @Test
-  public void fieldsStillHaveValuesWhenFieldValidationFailsInSubflow() throws Exception {
+  public void fieldsStillHaveValuesWhenFieldValidationFailsInSubflowNewIteration() throws Exception {
     var params = new HashMap<String, List<String>>();
     params.put("firstNameSubflow", List.of("tester"));
     params.put("textInputSubflow", List.of("text input value"));
@@ -159,7 +159,6 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
     assertEquals("Select C", page.getSelectValue("selectInputSubflow"));
   }
 
-  public final String uuidPatternString = "{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}}";
 
   @Test
   public void fieldsStillHaveValuesWhenFieldValidationFailsInSubflowPage2() throws Exception {
@@ -194,7 +193,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
     paramsPage2.put("selectInputSubflowPage2", List.of("Select C"));
     paramsPage2.put("moneyInputSubflowPage2", List.of("-11"));  // bad data
     paramsPage2.put("phoneInputSubflowPage2", List.of("(413) 123-1234"));
-    paramsPage2.put("dateSubflowPage2Day", List.of("12"));
+    paramsPage2.put("dateSubflowPage2Day", List.of("35"));
     paramsPage2.put("dateSubflowPage2Month", List.of("12"));
     paramsPage2.put("dateSubflowPage2Year", List.of("2012"));
 
@@ -202,8 +201,18 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
     int lastSlash = redirectedUrl.lastIndexOf('/');
     String pageNamePage2 = "subflowAddItemPage2/" + redirectedUrl.substring(lastSlash + 1);
     postExpectingFailure(pageNamePage2, paramsPage2, pageNamePage2);
+
     var page2 = new FormScreen(getPage("subflowAddItemPage2/" + redirectedUrl.substring(lastSlash)));
+    assertTrue(page2.hasDateInputError());
+    assertTrue(page2.hasInputError("numberInputSubflowPage2"));
+    assertTrue(page2.hasInputError("moneyInputSubflowPage2"));
+    assertFalse(page2.hasInputError("phoneInputSubflow"));
 
-
+    assertEquals("text input value", page2.getInputValue("textInputSubflowPage2"));
+    assertEquals("area input value", page2.getTextAreaValue("areaInputSubflowPage2"));
+    assertEquals(List.of("Checkbox-A"), page2.getCheckboxSetValues("checkboxSetSubflowPage2"));
+    assertEquals(List.of("checkbox-value"), page2.getCheckboxSetValues("checkboxInputSubflowPage2"));
+    assertEquals("Radio B", page2.getRadioValue("radioInputSubflowPage2"));
+    assertEquals("Select C", page2.getSelectValue("selectInputSubflowPage2"));
   }
 }

--- a/src/test/java/formflow/library/framework/InputsTest.java
+++ b/src/test/java/formflow/library/framework/InputsTest.java
@@ -73,7 +73,7 @@ public class InputsTest extends AbstractMockMvcTest {
     List<String> removedHiddenCheckboxInput = checkboxInput.stream().filter(e -> !e.isEmpty()).toList();
 
     assertThat(inputsScreen.getInputValue("textInput")).isEqualTo(textInput);
-    assertThat(inputsScreen.getTextAreaAreaValue("areaInput")).isEqualTo(areaInput);
+    assertThat(inputsScreen.getTextAreaValue("areaInput")).isEqualTo(areaInput);
     assertThat(inputsScreen.getInputValue("dateMonth")).isEqualTo(dateMonth);
     assertThat(inputsScreen.getInputValue("dateDay")).isEqualTo(dateDay);
     assertThat(inputsScreen.getInputValue("dateYear")).isEqualTo(dateYear);

--- a/src/test/java/formflow/library/inputs/TestFlow.java
+++ b/src/test/java/formflow/library/inputs/TestFlow.java
@@ -1,6 +1,8 @@
 package formflow.library.inputs;
 
 import formflow.library.data.FlowInputs;
+import formflow.library.data.validators.Money;
+import formflow.library.data.validators.Phone;
 import jakarta.validation.constraints.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,4 +85,38 @@ public class TestFlow extends FlowInputs {
   @NotBlank
   String validationOnZipCode;
   Boolean useValidatedValidationOn;
+
+  // now lets test some fields in a subflow
+  String firstNameSubflow;
+  @NotBlank
+  String textInputSubflow;
+  @NotBlank
+  String areaInputSubflow;
+  @NotBlank
+  String dateSubflowDay;
+  @NotBlank
+  String dateSubflowMonth;
+  @NotBlank
+  String dateSubflowYear;
+  @NotBlank(message = "Date may not be empty")
+  @Pattern(regexp = "\\d/\\d/\\d\\d\\d\\d", message = "Date must be in the format of mm/dd/yyyy")
+  String dateSubflowFull;
+
+  @NotBlank
+  @Max(value = 100)
+  String numberInputSubflow;
+  @NotEmpty
+  ArrayList<String> checkboxSetSubflow;
+  @NotEmpty
+  ArrayList<String> checkboxInputSubflow;
+  @NotBlank
+  String radioInputSubflow;
+  @NotBlank
+  String selectInputSubflow;
+  @NotBlank
+  @Money
+  String moneyInputSubflow;
+  @NotBlank
+  @Phone
+  String phoneInputSubflow;
 }

--- a/src/test/java/formflow/library/inputs/TestFlow.java
+++ b/src/test/java/formflow/library/inputs/TestFlow.java
@@ -119,4 +119,37 @@ public class TestFlow extends FlowInputs {
   @NotBlank
   @Phone
   String phoneInputSubflow;
+
+  // now lets test some fields in the second page of a subflow
+  String firstNameSubflowPage2;
+  @NotBlank
+  String textInputSubflowPage2;
+  @NotBlank
+  String areaInputSubflowPage2;
+  @NotBlank
+  String dateSubflowPage2Day;
+  @NotBlank
+  String dateSubflowPage2Month;
+  @NotBlank
+  String dateSubflowPage2Year;
+  @NotBlank(message = "Date may not be empty")
+  @Pattern(regexp = "\\d/\\d/\\d\\d\\d\\d", message = "Date must be in the format of mm/dd/yyyy")
+  String dateSubflowPage2Full;
+  @NotBlank
+  @Max(value = 100)
+  String numberInputSubflowPage2;
+  @NotEmpty
+  ArrayList<String> checkboxSetSubflowPage2;
+  @NotEmpty
+  ArrayList<String> checkboxInputSubflowPage2;
+  @NotBlank
+  String radioInputSubflowPage2;
+  @NotBlank
+  String selectInputSubflowPage2;
+  @NotBlank
+  @Money
+  String moneyInputSubflowPage2;
+  @NotBlank
+  @Phone
+  String phoneInputSubflowPage2;
 }

--- a/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
+++ b/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
@@ -43,6 +43,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.SharedHttpSessionConfigurer.sharedHttpSession;
 
@@ -211,6 +212,17 @@ public abstract class AbstractMockMvcTest {
             .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
             .params(new LinkedMultiValueMap<>(params))
     ).andExpect(redirectedUrl(redirectUrl));
+  }
+
+  protected ResultActions postToUrlExpectingSuccessRedirectPattern(String postUrl, String redirectUrlPattern,
+      Map<String, List<String>> params)
+      throws Exception {
+    return mockMvc.perform(
+        post(postUrl)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .params(new LinkedMultiValueMap<>(params))
+    ).andExpect(redirectedUrlPattern(redirectUrlPattern));
   }
 
   protected void postExpectingNextPageElementText(String pageName,

--- a/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
+++ b/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
@@ -316,7 +316,15 @@ public abstract class AbstractMockMvcTest {
     return postExpectingFailure(pageName, fixInputNamesForParams(Map.of(inputName, values)));
   }
 
-  protected ResultActions postExpectingFailure(String pageName, Map<String, List<String>> params)
+  protected ResultActions postExpectingFailure(String pageName, Map<String, List<String>> params) throws Exception {
+    return postExpectingFailure(pageName, params, pageName);
+  }
+
+  // we may not always go back to the page we started with.
+  // With subflows, we start with a post to 'someSubflowPage/new', but go back to the page without the '/new' in the case of
+  // validation errors
+  protected ResultActions postExpectingFailure(String pageName, Map<String, List<String>> params,
+      String redirectUrl)
       throws Exception {
 
     String postUrl = getUrlForPageName(pageName);
@@ -325,7 +333,7 @@ public abstract class AbstractMockMvcTest {
             .with(csrf())
             .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
             .params(new LinkedMultiValueMap<>(params))
-    ).andExpect(redirectedUrl(postUrl));
+    ).andExpect(redirectedUrl(getUrlForPageName(redirectUrl)));
   }
 
   protected ResultActions postExpectingFailures(String pageName, Map<String, String> params)
@@ -428,10 +436,12 @@ public abstract class AbstractMockMvcTest {
   }
 
   protected String getUrlForPageName(String pageName, String subflow) {
+    // TODO - remove assumption that flow is named testFlow - may not always be
     return "/flow/testFlow/" + pageName + "/" + subflow;
   }
 
   protected String getUrlForPageName(String pageName) {
+    // TODO - remove assumption that flow is named testFlow - may not always be
     return "/flow/testFlow/" + pageName;
   }
 
@@ -484,6 +494,7 @@ public abstract class AbstractMockMvcTest {
 
   @NotNull
   protected ResultActions getPage(String pageName) throws Exception {
+    // TODO - remove assumption that flow is named testFlow - may not always be
     return mockMvc.perform(get("/flow/testFlow/" + pageName));
   }
 
@@ -505,6 +516,7 @@ public abstract class AbstractMockMvcTest {
 
   @NotNull
   private String followRedirectsForPageName(String currentPageName) throws Exception {
+    // TODO - remove assumption that flow is named testFlow - may not always be
     var nextPage = "/flow/testFlow/" + currentPageName + "/navigation";
     while (Objects.requireNonNull(nextPage).contains("/navigation")) {
       // follow redirects

--- a/src/test/java/formflow/library/utilities/FormScreen.java
+++ b/src/test/java/formflow/library/utilities/FormScreen.java
@@ -29,8 +29,7 @@ public class FormScreen {
   }
 
   public boolean hasInputError(String inputName) {
-    Element element = html.select("input[name='%s'] ~ p.text--error".formatted(inputName))
-        .first();
+    Element element = html.select("[id^=\"%s-error-message\"]".formatted(inputName)).first();
     return element != null;
   }
 
@@ -142,7 +141,7 @@ public class FormScreen {
     return html.select(selector).first();
   }
 
-  public String getTextAreaAreaValue(String inputName) {
+  public String getTextAreaValue(String inputName) {
     return html.select("textarea[name='%s']".formatted(inputName)).text();
   }
 

--- a/src/test/java/formflow/library/utilities/SeleniumFactory.java
+++ b/src/test/java/formflow/library/utilities/SeleniumFactory.java
@@ -43,7 +43,7 @@ public class SeleniumFactory implements FactoryBean<RemoteWebDriver> {
     chromePrefs.put("download.default_directory", tempdir.toString());
     options.setExperimentalOption("prefs", chromePrefs);
     options.addArguments("--window-size=1280,1600");
-//   options.addArguments("--headless=new");
+    options.addArguments("--headless=new");
     options.addArguments("--remote-allow-origins=*");
     driver = new ChromeDriver(options);
   }

--- a/src/test/java/formflow/library/utilities/SeleniumFactory.java
+++ b/src/test/java/formflow/library/utilities/SeleniumFactory.java
@@ -43,7 +43,7 @@ public class SeleniumFactory implements FactoryBean<RemoteWebDriver> {
     chromePrefs.put("download.default_directory", tempdir.toString());
     options.setExperimentalOption("prefs", chromePrefs);
     options.addArguments("--window-size=1280,1600");
-    options.addArguments("--headless=new");
+//   options.addArguments("--headless=new");
     options.addArguments("--remote-allow-origins=*");
     driver = new ChromeDriver(options);
   }

--- a/src/test/resources/flows-config/test-flow.yaml
+++ b/src/test/resources/flows-config/test-flow.yaml
@@ -46,6 +46,6 @@ flow:
 subflows:
   testSubflow:
     entryScreen: testEntryScreen
-    iterationStartScreen: testIterationStartScreen
+    iterationStartScreen: subflowAddItem
     reviewScreen: testReviewScreen
     deleteConfirmationScreen: testDeleteConfirmationScreen

--- a/src/test/resources/flows-config/test-flow.yaml
+++ b/src/test/resources/flows-config/test-flow.yaml
@@ -21,6 +21,10 @@ flow:
   subflowAddItem:
     subflow: testSubflow
     nextScreens:
+      - name: subflowAddItemPage2
+  subflowAddItemPage2:
+    subflow: testSubflow
+    nextScreens:
       - name: test
   test:
     nextScreens:

--- a/src/test/resources/templates/testFlow/subflowAddItem.html
+++ b/src/test/resources/templates/testFlow/subflowAddItem.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
 <head th:replace="~{fragments/head :: head(title='Subflow Page')}"></head>
-<body >
+<body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
   <section class="slab">
@@ -9,16 +9,81 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block
             th:replace="~{fragments/cardHeader :: cardHeader(header='Subflow Page', subtext='This is a page within a subflow')}"/>
-            <!-- Test that the currentSubflowItem is passed in by the controller: -->
-            <div th:text="${currentSubflowItem.firstName}"></div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/continueButton :: continue}" />
-            </div>
+        <!-- Test that the currentSubflowItem is passed in by the controller: -->
+        <div th:text="${fieldData.firstNameSubflow}"></div>
+        <div>
+          <th:block
+              th:replace="~{fragments/inputs/text ::
+                                  text(inputName='textInputSubflow',
+                                  label='textInput')}"/>
+          <th:block th:replace="~{fragments/inputs/textArea ::
+                                textArea(inputName='areaInputSubflow',
+                                label='areaInput')}"/>
+          <th:block th:replace="~{fragments/inputs/date ::
+                                date(inputName='dateSubflow',
+                                label='dateInput',
+                                groupName='dateSubflowFull')}"/>
+          <th:block th:replace="~{fragments/inputs/number ::
+                                number(inputName='numberInputSubflow',
+                                label='numberInput')}"/>
+          <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
+                                checkboxFieldset(inputName='checkboxSetSubflow',
+                                label='checkboxSet',
+                                content=~{::checkboxContent})}">
+            <th:block th:ref="checkboxContent">
+              <th:block
+                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflow', value='Checkbox-A', label='Checkbox A')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflow', value='Checkbox-B', label='Checkbox B')}"/>
+            </th:block>
           </th:block>
+          <th:block
+              th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='checkboxInputSubflow', value='checkbox-value', label='Single checkbox')}"/>
+          <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                                radioFieldset(inputName='radioInputSubflow',
+                                label='radioInput',
+                                content=~{::radioContent})}">
+            <th:block th:ref="radioContent">
+              <th:block
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio A', label='Radio A')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio B', label='Radio B')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio C', label='Radio C')}"/>
+            </th:block>
+          </th:block>
+          <th:block
+              th:replace="~{fragments/inputs/select ::
+                                select(inputName='selectInputSubflow',
+                                       label='selectInput',
+                                       content=~{::selectContent})}">
+            <th:block th:ref="selectContent">
+              <th:block
+                  th:replace="~{fragments/inputs/selectOption :: selectOption(value='', optionText='Choose one')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/selectOption :: selectOption(value='Select A', optionText='Select A')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/selectOption :: selectOption(value='Select B', optionText='Select B')}"/>
+              <th:block
+                  th:replace="~{fragments/inputs/selectOption :: selectOption(value='Select C', optionText='Select C')}"/>
+            </th:block>
+          </th:block>
+          <th:block
+              th:replace="~{fragments/inputs/money :: money(
+                                  inputName='moneyInputSubflow',
+                                  label='moneyInput')}"/>
+          <th:block
+              th:replace="~{fragments/inputs/phone :: phone(
+                                  inputName='phoneInputSubflow',
+                                  label='phoneInput')}"/>
+        </div>
+        <div class="form-card__footer">
+          <th:block th:replace="~{fragments/continueButton :: continue}"/>
+        </div>
       </main>
     </div>
   </section>
 </div>
-<th:block th:replace="~{fragments/footer :: footer}" />
+<th:block th:replace="~{fragments/footer :: footer}"/>
 </body>
 </html>

--- a/src/test/resources/templates/testFlow/subflowAddItemPage2.html
+++ b/src/test/resources/templates/testFlow/subflowAddItemPage2.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title='Subflow Page')}"></head>
+<head th:replace="~{fragments/head :: head(title='Subflow Page2')}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -10,51 +10,47 @@
         <th:block
             th:replace="~{fragments/cardHeader :: cardHeader(header='Subflow Page', subtext='This is a page within a subflow')}"/>
         <!-- Test that the currentSubflowItem is passed in by the controller: -->
-        <div th:text="${currentSubflowItem.firstNameSubflow}"></div>
+        <div th:text="${currentSubflowItem.firstNameSubflowPage2}"></div>
         <div>
           <th:block
               th:replace="~{fragments/inputs/text ::
-                                  text(inputName='textInputSubflow',
+                                  text(inputName='textInputSubflowPage2',
                                   label='textInput')}"/>
           <th:block th:replace="~{fragments/inputs/textArea ::
-                                textArea(inputName='areaInputSubflow',
+                                textArea(inputName='areaInputSubflowPage2',
                                 label='areaInput')}"/>
-          <th:block th:replace="~{fragments/inputs/date ::
-                                date(inputName='dateSubflow',
-                                label='dateInput',
-                                groupName='dateSubflowFull')}"/>
           <th:block th:replace="~{fragments/inputs/number ::
-                                number(inputName='numberInputSubflow',
+                                number(inputName='numberInputSubflowPage2',
                                 label='numberInput')}"/>
           <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
-                                checkboxFieldset(inputName='checkboxSetSubflow',
+                                checkboxFieldset(inputName='checkboxSetSubflowPage2',
                                 label='checkboxSet',
                                 content=~{::checkboxContent})}">
             <th:block th:ref="checkboxContent">
               <th:block
-                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflow', value='Checkbox-A', label='Checkbox A')}"/>
+                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflowPage2', value='Checkbox-A', label='Checkbox A')}"/>
               <th:block
-                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflow', value='Checkbox-B', label='Checkbox B')}"/>
+                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSetSubflowPage2', value='Checkbox-B', label='Checkbox B')}"/>
             </th:block>
           </th:block>
           <th:block
-              th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='checkboxInputSubflow', value='checkbox-value', label='Single checkbox')}"/>
+              th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='checkboxInputSubflowPage2', value='checkbox-value', label='Single checkbox')}"/>
           <th:block th:replace="~{fragments/inputs/radioFieldset ::
-                                radioFieldset(inputName='radioInputSubflow',
+                                radioFieldset(inputName='radioInputSubflowPage2',
                                 label='radioInput',
                                 content=~{::radioContent})}">
             <th:block th:ref="radioContent">
               <th:block
-                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio A', label='Radio A')}"/>
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflowPage2',value='Radio A', label='Radio A')}"/>
               <th:block
-                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio B', label='Radio B')}"/>
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflowPage2',value='Radio B', label='Radio B')}"/>
               <th:block
-                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflow',value='Radio C', label='Radio C')}"/>
+                  th:replace="~{fragments/inputs/radio :: radio(inputName='radioInputSubflowPage2',value='Radio C', label='Radio C')}"/>
             </th:block>
           </th:block>
           <th:block
               th:replace="~{fragments/inputs/select ::
-                                select(inputName='selectInputSubflow',
+                                select(inputName='selectInputSubflowPage2',
                                        label='selectInput',
                                        content=~{::selectContent})}">
             <th:block th:ref="selectContent">
@@ -70,11 +66,11 @@
           </th:block>
           <th:block
               th:replace="~{fragments/inputs/money :: money(
-                                  inputName='moneyInputSubflow',
+                                  inputName='moneyInputSubflowPage2',
                                   label='moneyInput')}"/>
           <th:block
               th:replace="~{fragments/inputs/phone :: phone(
-                                  inputName='phoneInputSubflow',
+                                  inputName='phoneInputSubflowPage2',
                                   label='phoneInput')}"/>
         </div>
         <div class="form-card__footer">


### PR DESCRIPTION
Addresses testing of fix for: https://www.pivotaltracker.com/story/show/185546386

This adds a test of error handling on:
 * the first page of a subflow: the url `/flow/someflow/someSubflowPage/new` 
 * for an inner page of a subflow (one with established UUID): `/flow/someflow/someInnerSubflowPage/12301-eb2...`

I was noticing that subflow data was getting merged into the `inputData` at the top level in the `inputData` passed back to the page, via the Model. This separates that a bit more. It's now in the right spot in the `inputData` as well as in the `fieldData` passed as part of the Model to a page.  
