### PR TITLE
Upgrades 'org.springframework.boot' to version '3.1.2' and flyway to 9.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // Apply the java-library plugin for API and implementation separation.
-    id 'org.springframework.boot' version '3.1.1'
+    id 'org.springframework.boot' version '3.1.2'
     id 'io.spring.dependency-management' version '1.1.2'
     id 'java-library'
     id 'maven-publish'
@@ -67,7 +67,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:24.0.1'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.5.1'
     implementation 'javax.persistence:javax.persistence-api:2.2'
-    implementation 'org.flywaydb:flyway-core:9.19.4'
+    implementation 'org.flywaydb:flyway-core:9.21.0'
     implementation 'net.coobird:thumbnailator:0.4.20'
     implementation 'org.webjars.npm:dropzone:5.9.3'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.364'


### PR DESCRIPTION

We had previously held off on upgrading FlyWay, due to some changes that were incompatible with Spring Boot. Spring Boot made fixes in version 3.1.2, so now we can upgrade these libraries. 

https://github.com/spring-projects/spring-boot/issues/36029
https://github.com/flyway/flyway/issues/3694#issuecomment-1645499387

