### PR TITLE
Increase release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           until curl -s -f -o /dev/null "https://central.sonatype.com/artifact/org.codeforamerica.platform/form-flow/${{inputs.version}}"
           do
             echo "Waiting for version ${{ inputs.version }} to be published to Sonatype..."
-            sleep 5
+            sleep 30
           done
       - name: "Announce failure to release of ${{inputs.version}} to #platform-help"
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.PLATFORM_ROBOT_GPG_PRIVATE_KEY }}
           GPG_SIGNING_PASSPHRASE: ${{ secrets.PLATFORM_ROBOT_GPG_PASSPHRASE }}
       - name: Confirm version ${{ inputs.version }} published to Sonatype
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           until curl -s -f -o /dev/null "https://central.sonatype.com/artifact/org.codeforamerica.platform/form-flow/${{inputs.version}}"
           do


### PR DESCRIPTION
# Why?

@bseeger and I thought that checking the status of the new version in maven central every 5 seconds for up to 60 mins (up to 720 times) was too much and might result in us getting rate limited, though that is just speculation on our part.

So we increased to every 30 seconds for up to 60 mins (up to 120 times).

Also, seems like a max limit of 60 mins is not enough 😢 