### PR TITLE
Delete other jars when you jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,13 @@ def sonatypeUsername = localEnv.getProperty("SONATYPE_USERNAME") ?: System.geten
 def sonatypePassword = localEnv.getProperty("SONATYPE_PASSWORD") ?: System.getenv("SONATYPE_PASSWORD")
 
 jar {
-    delete "build", "/libs/", "*.jar"
+    doFirst {
+        fileTree(dir: "$buildDir/libs", include: '*.jar').each { file ->
+            if (!file.name.contains(version)) {
+                file.delete()
+            }
+        }
+    }
     manifest {
         attributes "Main-Class": "formflow.library.ScreenController"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ def sonatypeUsername = localEnv.getProperty("SONATYPE_USERNAME") ?: System.geten
 def sonatypePassword = localEnv.getProperty("SONATYPE_PASSWORD") ?: System.getenv("SONATYPE_PASSWORD")
 
 jar {
+    delete "build", "/libs/", "*.jar"
     manifest {
         attributes "Main-Class": "formflow.library.ScreenController"
     }


### PR DESCRIPTION
- Once snapshots switch over, multiple jars sit in the build directory. This confuses starter-app locally since it can pick the wrong jar