### PR TITLE
Moves the adding of the '.pdf' extension to the PdfService::generatePdfName() method

### DIFF
--- a/src/main/java/formflow/library/PdfController.java
+++ b/src/main/java/formflow/library/PdfController.java
@@ -59,7 +59,7 @@ public class PdfController extends FormFlowController {
       byte[] data = pdfService.getFilledOutPDF(maybeSubmission.get());
 
       headers.add(HttpHeaders.CONTENT_DISPOSITION,
-          "attachment; filename=%s.pdf".formatted(pdfService.generatePdfName(submission)));
+          "attachment; filename=%s".formatted(pdfService.generatePdfName(submission)));
       return ResponseEntity
           .ok()
           .contentType(MediaType.APPLICATION_OCTET_STREAM)

--- a/src/main/java/formflow/library/pdf/PdfService.java
+++ b/src/main/java/formflow/library/pdf/PdfService.java
@@ -34,12 +34,12 @@ public class PdfService {
   }
 
   /**
-   * Generates a generic pdf file name from a flow and submissionId
+   * Generates a generic pdf file name from the flow and submission id that are part of the Submission.
    *
-   * @param submission
-   * @return a generic filename string
+   * @param submission Submission to create the PDF filename for
+   * @return a generic filename string, including the '.pdf' extension
    */
   public String generatePdfName(Submission submission) {
-    return String.format("%s_%s", submission.getFlow(), submission.getId().toString());
+    return String.format("%s_%s.pdf", submission.getFlow(), submission.getId().toString());
   }
 }

--- a/src/test/java/formflow/library/controllers/PdfControllerTest.java
+++ b/src/test/java/formflow/library/controllers/PdfControllerTest.java
@@ -56,7 +56,7 @@ public class PdfControllerTest extends AbstractMockMvcTest {
     when(submissionRepositoryService.findById(any())).thenReturn(Optional.of(submission));
     super.setUp();
   }
-  
+
   @Test
   void shouldReturn404WhenFlowDoesNotExist() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.get("/download/{flow}/{submissionId}", "flowThatDoesNotExist", "submissionId"))
@@ -68,7 +68,7 @@ public class PdfControllerTest extends AbstractMockMvcTest {
     session.setAttribute("id", submission.getId());
     MvcResult result = mockMvc.perform(get("/download/ubi/" + submission.getId()).session(session))
         .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=%s.pdf".formatted(pdfService.generatePdfName(submission))))
+            "attachment; filename=%s".formatted(pdfService.generatePdfName(submission))))
         .andExpect(status().is2xxSuccessful())
         .andReturn();
     assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(filledPdfByteArray);


### PR DESCRIPTION
## Ticket information
Resolves: https://www.pivotaltracker.com/story/show/185701727
Also updates tests as necessary.

## Ripple effect(s) of change
 * PEBT has one spot to change in regards to this in a test: https://github.com/codeforamerica/homeschool-pebt/blob/236c103ad13c65e1a2ff62a114629f98a68c6915/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java#L207. (there code will still work fine even if it's not changed, due to the code in between)
 * LA Doc Uploader - no ripple effects, they don't use the PDF feature

