### PR TITLE
Fix page-wrapper padding issue

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
@@ -291,11 +291,6 @@ url('/webjars/form-flow/0.0.1/fonts/MaterialIcons-Regular.svg') format('svg');
   background-image: url('/webjars/form-flow/0.0.1/images/emojis/crossmark.png');
 }
 
-/* TODO: delete/fix in other way */
-.page-wrapper {
-  padding-bottom: 253px;
-}
-
 @media screen and (min-width: 601px) {
   .toolbar__wrapper {
     margin-left: -3.5rem;
@@ -339,6 +334,10 @@ url('/webjars/form-flow/0.0.1/fonts/MaterialIcons-Regular.svg') format('svg');
   border: 2px solid #AAAAAA;
   border-radius: 3px;
   max-width: 35rem;
+}
+
+body {
+  margin-bottom: initial;
 }
 
 body,
@@ -434,6 +433,7 @@ body,
 .main-footer {
   font-weight: normal;
   height: auto;
+  position: static;
 }
 
 .slab a:not(.button):not(.reveal__link):not(.text--red),


### PR DESCRIPTION
[#185407394](https://www.pivotaltracker.com/story/show/185407394)

- Remove `body` `margin-bottom` from honeycrisp
- Remove `.main-footer` `position` so that it is in the DOM flow

Tested on:
* Desktop Chromium
* Desktop Firefox
* Desktop Safari
* iOS Safari

**Screen with no spacing issue:**
<img width="857" alt="Screenshot 2023-08-31 at 1 53 59 PM" src="https://github.com/codeforamerica/form-flow/assets/9101728/5bafe7e5-c710-461e-9bc9-fca57a498b95">

