### PR TITLE
Update date fieldset to use legend instead of label

### DIFF
--- a/src/main/resources/templates/fragments/inputs/date.html
+++ b/src/main/resources/templates/fragments/inputs/date.html
@@ -19,7 +19,7 @@
   <div
       th:class="'form-group' + ${((hasErrorMonth || hasErrorDay || hasErrorYear) ? ' form-group--error' : '')}">
     <fieldset th:id="${groupName}" class="input-group input-group--inline">
-      <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}"
+      <legend th:if="${hasLabel}" th:for="${inputName}" th:text="${label}"
              class="form-question"/>
       <p class="text--help">
         <label th:for="${inputName}+'-month'"


### PR DESCRIPTION
- Screen readers were not properly reading the label as it was not being associated with the fieldset. Legend is the more proper semantic HTML element for use with fieldsets.