### PR TITLE
Add template resolver for a new location for uswds templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,9 +1182,11 @@ The address fragment has two required parameters, `validate` and `inputName`.
 
 - `validate` is a boolean value that determines whether the address should be validated by Smarty
 - `inputName` is the name that will be associated with all of the above inputs by being used as a
-prefix in their input's name. For example, if the `inputName` is `homeAddress` then the corresponding
-inputs will be `homeAddressStreetAddress1`, `homeAddressStreetAddress2`, `homeAddressCity`, `homeAddressState`,
-and `homeAddressZipCode`.
+  prefix in their input's name. For example, if the `inputName` is `homeAddress` then the
+  corresponding
+  inputs will
+  be `homeAddressStreetAddress1`, `homeAddressStreetAddress2`, `homeAddressCity`, `homeAddressState`,
+  and `homeAddressZipCode`.
 
 The address fragment has five optional
 parameters: `streetAddressHelpText`, `streetAddress2HelpText`, `cityHelpText`, `stateHelpText`
@@ -1195,7 +1197,8 @@ Please note that when using the address fragment you will need to create corresp
 your
 flow inputs class for each of the above-mentioned inputs created by the fragment. For example, if
 your
-address fragments input name is `mailingAddress`, then you will need to create the following fields in
+address fragments input name is `mailingAddress`, then you will need to create the following fields
+in
 your flow inputs class:
 
 ```
@@ -2346,6 +2349,17 @@ your `application.yaml` like such:
 form-flow:
   path: 'name-of-file.yaml'
 ```
+
+#### Design System
+
+We are moving towards using a [custom theme](https://codeforamerica.github.io/uswds/dist/) of
+the [US Web Design System(USWDS)](https://designsystem.digital.gov/). Enabling this
+property will add another template location in Thymeleaf for USWDS templates to be consumed.
+
+| Property                       | Default | Description                                                                                                                             |
+|--------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `form-flow.design-system.name` | none    | Can use `cfa-uswds` to enable the new CfA USWDS design system assets and templates. Otherwise Honeycrisp assets and templates are used. |
+|
 
 #### File upload properties
 

--- a/README.md
+++ b/README.md
@@ -2353,12 +2353,19 @@ form-flow:
 #### Design System
 
 We are moving towards using a [custom theme](https://codeforamerica.github.io/uswds/dist/) of
-the [US Web Design System(USWDS)](https://designsystem.digital.gov/). Enabling this
-property will add another template location in Thymeleaf for USWDS templates to be consumed.
+the [US Web Design System (USWDS)](https://designsystem.digital.gov/). Enabling this
+property will set template resolution to use USWDS styling in place of Honeycrisp. The USWDS 
+template location will become the default for your application, pulling USWDS styles, templates and fragments
+in place of Honeycrisp ones. The USWDS file path will be `/resources/cfa-uswds-templates/`. You can 
+override templates and fragments in this path by placing a file with the same name and path in your
+application. For example, placing a file at `/resources/cfa-uswds-templates/fragments/example.html` 
+would override the fragment with the same name in the USWDS fragments folder.
+
+You can view all the USWDS templates and fragments in the [USWDS templates folder](https://github.com/codeforamerica/form-flow/tree/main/src/main/resources/cfa-uswds-templates).
 
 | Property                       | Default | Description                                                                                                                             |
 |--------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `form-flow.design-system.name` | none    | Can use `cfa-uswds` to enable the new CfA USWDS design system assets and templates. Otherwise Honeycrisp assets and templates are used. |
+| `form-flow.design-system.name` | none    | Can use `cfa-uswds` to enable the CfA USWDS design system assets and templates. Otherwise Honeycrisp assets and templates are used.     |
 |
 
 #### File upload properties

--- a/src/main/java/formflow/library/config/ThymeleafConfiguration.java
+++ b/src/main/java/formflow/library/config/ThymeleafConfiguration.java
@@ -1,35 +1,39 @@
 package formflow.library.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 /**
- * Provides configuration for the Thymeleaf templates.
+ * Provides configuration for the Thymeleaf templates, besides the default.
  */
 @Configuration
+@Slf4j
 public class ThymeleafConfiguration {
 
   /**
-   * Creates a new SpringResourceTemplateResolver and configures it so it knows where to locate the templates and how to read
-   * them.
+   * Creates a new ClassLoaderTemplateResolver to be able to resolve templates in the {@code cfa-uswds-templates/} directory.
    *
    * <p>
-   * The resolver will be configured to look in the {@code templates/} directory for {@code .html} files. The assumed encoding
-   * will be {@code UTF-8}.  The templates will not be cached.
+   * The resolver will be configured to look in the {@code cfa-uswds-templates} directory for {@code .html} files. The assumed
+   * encoding will be {@code UTF-8}.  The templates will not be cached.
    * </p>
    *
-   * @return a new resolver configured to work with templates
+   * @return a new resolver configured to work with library uswds templates.
    */
   @Bean
-  public SpringResourceTemplateResolver secondaryTemplateResolver() {
-    SpringResourceTemplateResolver secondaryTemplateResolver = new SpringResourceTemplateResolver();
-    secondaryTemplateResolver.setPrefix("templates/");
+  @ConditionalOnProperty(name = "form-flow.design-system.name", havingValue = "cfa-uswds")
+  public ClassLoaderTemplateResolver cfaUswdsTemplateResolver() {
+    log.info("Template resolution has been set to include the path `cfa-uswds-templates/`.");
+    ClassLoaderTemplateResolver secondaryTemplateResolver = new ClassLoaderTemplateResolver();
+    secondaryTemplateResolver.setPrefix("cfa-uswds-templates/");
     secondaryTemplateResolver.setSuffix(".html");
     secondaryTemplateResolver.setTemplateMode(TemplateMode.HTML);
     secondaryTemplateResolver.setCharacterEncoding("UTF-8");
-    secondaryTemplateResolver.setOrder(1);
+    secondaryTemplateResolver.setOrder(0);
     secondaryTemplateResolver.setCheckExistence(true);
     secondaryTemplateResolver.setCacheable(false);
 

--- a/src/main/resources/cfa-uswds-templates/fragments/libraryHead.html
+++ b/src/main/resources/cfa-uswds-templates/fragments/libraryHead.html
@@ -1,0 +1,3 @@
+<th:block th:fragment="headLinks">
+  <!-- CFA USWDS Links -->
+</th:block>

--- a/src/test/java/formflow/library/config/ThymeleafConfigurationLoadedTest.java
+++ b/src/test/java/formflow/library/config/ThymeleafConfigurationLoadedTest.java
@@ -2,30 +2,26 @@ package formflow.library.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.thymeleaf.TemplateEngine;
 import org.junit.jupiter.api.Test;
-import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
-@SpringBootTest(classes = {ThymeleafConfiguration.class}, properties = {"form-flow.design-system.name=cfa-uswds"})
 @ImportAutoConfiguration(ThymeleafAutoConfiguration.class)
-class ThymeleafConfigurationTest {
-
-  @Autowired
-  private ThymeleafConfiguration thymeleafConfiguration;
+@SpringBootTest(classes = {ThymeleafConfiguration.class}, properties = {"form-flow.design-system.name=cfa-uswds"})
+public class ThymeleafConfigurationLoadedTest {
 
   @Autowired
   private TemplateEngine templateEngine;
 
   @Test
   void checkThatUSWDSTemplateResolverIsLoaded() {
-    System.out.println(templateEngine.getTemplateResolvers());
     assertThat(templateEngine.getTemplateResolvers().size()).isEqualTo(2);
-
-    assertThat(thymeleafConfiguration).isEqualTo("test");
+    var uswdsResolver = templateEngine.getTemplateResolvers().stream()
+        .filter(x -> Objects.equals(x.getName(), "org.thymeleaf.templateresolver.ClassLoaderTemplateResolver")).findFirst();
+    assertThat(uswdsResolver).isPresent();
   }
-
 }

--- a/src/test/java/formflow/library/config/ThymeleafConfigurationTest.java
+++ b/src/test/java/formflow/library/config/ThymeleafConfigurationTest.java
@@ -1,0 +1,31 @@
+package formflow.library.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.thymeleaf.TemplateEngine;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+@SpringBootTest(classes = {ThymeleafConfiguration.class}, properties = {"form-flow.design-system.name=cfa-uswds"})
+@ImportAutoConfiguration(ThymeleafAutoConfiguration.class)
+class ThymeleafConfigurationTest {
+
+  @Autowired
+  private ThymeleafConfiguration thymeleafConfiguration;
+
+  @Autowired
+  private TemplateEngine templateEngine;
+
+  @Test
+  void checkThatUSWDSTemplateResolverIsLoaded() {
+    System.out.println(templateEngine.getTemplateResolvers());
+    assertThat(templateEngine.getTemplateResolvers().size()).isEqualTo(2);
+
+    assertThat(thymeleafConfiguration).isEqualTo("test");
+  }
+
+}

--- a/src/test/java/formflow/library/config/ThymeleafConfigurationUnloadedTest.java
+++ b/src/test/java/formflow/library/config/ThymeleafConfigurationUnloadedTest.java
@@ -1,0 +1,27 @@
+package formflow.library.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.thymeleaf.TemplateEngine;
+
+@ImportAutoConfiguration(ThymeleafAutoConfiguration.class)
+@SpringBootTest(classes = {ThymeleafConfiguration.class}, properties = {"form-flow.design-system.name=honeycrisp"})
+public class ThymeleafConfigurationUnloadedTest {
+
+  @Autowired
+  private TemplateEngine templateEngine;
+
+  @Test
+  void checkThatUSWDSTemplateResolverIsLoaded() {
+    assertThat(templateEngine.getTemplateResolvers().size()).isEqualTo(1);
+    var uswdsResolver = templateEngine.getTemplateResolvers().stream()
+        .filter(x -> Objects.equals(x.getName(), "org.thymeleaf.templateresolver.ClassLoaderTemplateResolver")).findFirst();
+    assertThat(uswdsResolver).isNotPresent();
+  }
+}


### PR DESCRIPTION
* [Ticket #185770089](https://www.pivotaltracker.com/story/show/185770089)
* [Starter app PR](https://github.com/codeforamerica/form-flow-starter-app/pull/226)

**Question for reviewer:**
I had to create both `ThymeleafConfigurationUnloadedTest` and `ThymeleafConfigurationLoadedTest` in separate files so that I could load different application properties. Ideally I would like it to be in one file, maybe with nested classes, but I wasn't able to figure it out. If you have suggestions that would improve this, I'm very open to it.