### PR TITLE
Add method to user file map

### DIFF
--- a/src/main/java/formflow/library/utils/UserFileMap.java
+++ b/src/main/java/formflow/library/utils/UserFileMap.java
@@ -25,6 +25,14 @@ public class UserFileMap {
     userFileMap = new HashMap<>();
   }
 
+  /**
+   * Adds a file into the UserFileMap.
+   *
+   * @param flow         the flow the associate the file with
+   * @param inputName    the name of the input the file was gathered through
+   * @param userFile     the UserFile to add
+   * @param thumbDataUrl the base64 encoded thumbnail image of the file
+   */
   public void addUserFileToMap(String flow, String inputName, UserFile userFile, String thumbDataUrl) {
     Map<String, String> fileInfo = UserFile.createFileInfo(userFile, thumbDataUrl);
 
@@ -39,8 +47,13 @@ public class UserFileMap {
     userFileMap.get(flow).get(inputName).put(userFile.getFileId(), fileInfo);
   }
 
+  /**
+   * Removes a specific file from the UserFileMap.
+   *
+   * @param flow   flow the file is apart of
+   * @param fileId UUID of the file to remove
+   */
   public void removeUserFileFromMap(String flow, UUID fileId) {
-
     if (userFileMap.get(flow) == null) {
       log.warn("Unable to remove fileId '{}' from flow '{}'. Flow does not exist",
           fileId.toString(), flow);
@@ -62,7 +75,21 @@ public class UserFileMap {
     }
   }
 
+  /**
+   * Utility method to extract the file info map from the UserFileMap. The map maps a file's UUID to its file information. The
+   * following information is in the map: 'originalFilename', 'filesize', 'thumbnailUrl', and 'type'.
+   *
+   * @param flow      flow the files are associated with
+   * @param inputName name of the input widget that the files were gathered through
+   * @return Returns a map of UserFile UUIDs mapped to key/value string pairs of data about the file
+   */
   public Map<UUID, Map<String, String>> getFiles(String flow, String inputName) {
+    if (userFileMap.get(flow) == null) {
+      log.warn("Unable to get files for flow '{}' for input named '{}'. Flow not found in mapping.", flow, inputName);
+      throw new IndexOutOfBoundsException(
+          String.format("Flow '%s' does not exist", flow)
+      );
+    }
     return userFileMap.get(flow).get(inputName);
   }
 }

--- a/src/main/java/formflow/library/utils/UserFileMap.java
+++ b/src/main/java/formflow/library/utils/UserFileMap.java
@@ -61,4 +61,8 @@ public class UserFileMap {
       userFileMap.remove(flow);
     }
   }
+
+  public Map<UUID, Map<String, String>> getFiles(String flow, String inputName) {
+    return userFileMap.get(flow).get(inputName);
+  }
 }

--- a/src/test/java/formflow/library/controllers/FileControllerTest.java
+++ b/src/test/java/formflow/library/controllers/FileControllerTest.java
@@ -135,7 +135,6 @@ public class FileControllerTest extends AbstractMockMvcTest {
 
     ObjectMapper objectMapper = new ObjectMapper();
     UserFileMap userFileMap = objectMapper.readValue(session.getAttribute("userFiles").toString(), UserFileMap.class);
-
     // get the DZ Instance Map from the session and make sure the file info looks okay
     assertThat(userFileMap.getUserFileMap().size()).isEqualTo(1);
     assertThat(userFileMap.getUserFileMap().get("testFlow").size()).isEqualTo(1);
@@ -146,6 +145,10 @@ public class FileControllerTest extends AbstractMockMvcTest {
     assertThat(fileData.get("filesize")).isEqualTo("4.0");
     assertThat(fileData.get("thumbnailUrl")).isEqualTo("base64string");
     assertThat(fileData.get("type")).isEqualTo(MediaType.IMAGE_JPEG_VALUE);
+
+    // also test using the UserFileMap.getFiles() method to ensure it works okay here too.
+    Map<UUID, Map<String, String>> filesDirect = userFileMap.getFiles("testFlow", "dropZoneTestInstance");
+    assertThat(filesDirect.get(theNewFileId)).isEqualTo(fileData);
   }
 
   @Test


### PR DESCRIPTION
This adds a convenience method to get the user files from the UserFileMap, based on `flow` and `inputName`. 
We have the ability to call `getUserFileMap()`, but that provides the entire map and then the user (in this case a utility class supporting a thymeleaf template) will have to do the digging through it.  Seems like a nice thing for use to encapsulate the complexity of that data structure. 

This also fills in Javadoc information for the UserFileMap class as well as adds a quick test for the new method. 

