### PR TITLE
Fixes a flow issue where navigation went to the wrong spot.

### DIFF
--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -460,13 +460,18 @@ public class ScreenController extends FormFlowController {
 
     boolean isCurrentScreenLastInSubflow = getScreenConfig(flow, nextScreen).getSubflow() == null;
     String redirectString;
-    if (uuid != null && isCurrentScreenLastInSubflow) {
-      submission.setIterationIsCompleteToTrue(currentScreen.getSubflow(), uuid);
-      submission = saveToRepository(submission);
-      redirectString = String.format("/flow/%s/%s", flow, nextScreen);
+    if (uuid != null) {
+      if (isCurrentScreenLastInSubflow) {
+        submission.setIterationIsCompleteToTrue(currentScreen.getSubflow(), uuid);
+        submission = saveToRepository(submission);
+        redirectString = String.format("/flow/%s/%s", flow, nextScreen);
+      } else {
+        redirectString = String.format("/flow/%s/%s/%s", flow, nextScreen, uuid);
+      }
     } else {
-      redirectString = String.format("/flow/%s/%s/%s", flow, nextScreen, uuid);
+      redirectString = String.format("/flow/%s/%s", flow, nextScreen);
     }
+
     log.info("navigation: flow: " + flow + ", nextScreen: " + nextScreen);
     return new ModelAndView(new RedirectView(redirectString));
   }


### PR DESCRIPTION
The demo site is broken as the navigation method adds a `/null` to represent `uuid` even when we're not in a subflow. 

The code was assuming we were always in a subflow, after a POST. 

Co-Authored-By: Lauren Kemperman; lkemperman@codeforamerica.org