### PR TITLE
only check pattern if value is not null

### DIFF
--- a/src/main/java/formflow/library/data/validators/MoneyValidator.java
+++ b/src/main/java/formflow/library/data/validators/MoneyValidator.java
@@ -22,6 +22,9 @@ public class MoneyValidator implements ConstraintValidator<Money, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return value == null || Pattern.matches("(^(0|([1-9]\\d*))?(\\.\\d{1,2})?$)?", value);
+    if (value != null){
+      return Pattern.matches("(^(0|([1-9]\\d*))?(\\.\\d{1,2})?$)?", value);
+    }
+    return true;
   }
 }

--- a/src/main/java/formflow/library/data/validators/MoneyValidator.java
+++ b/src/main/java/formflow/library/data/validators/MoneyValidator.java
@@ -22,7 +22,7 @@ public class MoneyValidator implements ConstraintValidator<Money, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    if (value != null){
+    if (value != null && !value.isBlank()){
       return Pattern.matches("(^(0|([1-9]\\d*))?(\\.\\d{1,2})?$)?", value);
     }
     return true;

--- a/src/main/java/formflow/library/data/validators/MoneyValidator.java
+++ b/src/main/java/formflow/library/data/validators/MoneyValidator.java
@@ -22,6 +22,6 @@ public class MoneyValidator implements ConstraintValidator<Money, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return Pattern.matches("(^(0|([1-9]\\d*))?(\\.\\d{1,2})?$)?", value);
+    return value == null || Pattern.matches("(^(0|([1-9]\\d*))?(\\.\\d{1,2})?$)?", value);
   }
 }

--- a/src/main/java/formflow/library/data/validators/PhoneValidator.java
+++ b/src/main/java/formflow/library/data/validators/PhoneValidator.java
@@ -21,7 +21,7 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    if (value != null) {
+    if (value != null && !value.isBlank()){
       return Pattern.matches("(\\([2-9][0-8][0-9]\\)\\s\\d{3}-\\d{4})", value);
     }
     return true;

--- a/src/main/java/formflow/library/data/validators/PhoneValidator.java
+++ b/src/main/java/formflow/library/data/validators/PhoneValidator.java
@@ -21,6 +21,6 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return Pattern.matches("(\\([2-9][0-8][0-9]\\)\\s\\d{3}-\\d{4})", value);
+    return value == null || Pattern.matches("(\\([2-9][0-8][0-9]\\)\\s\\d{3}-\\d{4})", value);
   }
 }

--- a/src/main/java/formflow/library/data/validators/PhoneValidator.java
+++ b/src/main/java/formflow/library/data/validators/PhoneValidator.java
@@ -21,6 +21,9 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
    */
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return value == null || Pattern.matches("(\\([2-9][0-8][0-9]\\)\\s\\d{3}-\\d{4})", value);
+    if (value != null) {
+      return Pattern.matches("(\\([2-9][0-8][0-9]\\)\\s\\d{3}-\\d{4})", value);
+    }
+    return true;
   }
 }


### PR DESCRIPTION
Based on conversation with @bseeger @sree-cfa @spokenbird @lkemperman-cfa 

the missing null check is causing a null pointer exception in the LA doc Uploader test. 

```
Caused by:
        java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
            at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1769)
            at java.base/java.util.regex.Matcher.reset(Matcher.java:415)
            at java.base/java.util.regex.Matcher.<init>(Matcher.java:252)
            at java.base/java.util.regex.Pattern.matcher(Pattern.java:1134)
            at java.base/java.util.regex.Pattern.matches(Pattern.java:1175)
            at formflow.library.data.validators.MoneyValidator.isValid(MoneyValidator.java:15)
            at formflow.library.data.validators.MoneyValidator.isValid(MoneyValidator.java:11)```