### PR TITLE
Remove @Transactional annotation from services

### DIFF
--- a/src/main/java/formflow/library/data/SubmissionRepositoryService.java
+++ b/src/main/java/formflow/library/data/SubmissionRepositoryService.java
@@ -1,19 +1,16 @@
 package formflow.library.data;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 /**
  * Service to retrieve and store {@link formflow.library.data.Submission} objects in the database.
  */
 @Service
-@Transactional
 @Slf4j
 public class SubmissionRepositoryService {
 

--- a/src/main/java/formflow/library/data/UserFile.java
+++ b/src/main/java/formflow/library/data/UserFile.java
@@ -20,6 +20,7 @@ import lombok.ToString;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.SourceType;
 import org.springframework.stereotype.Component;
 
@@ -66,6 +67,7 @@ public class UserFile {
   @Column(name = "virus_scanned")
   private boolean virusScanned;
 
+  @Generated
   @Column(name = "doc_type_label")
   private String docTypeLabel;
 

--- a/src/main/java/formflow/library/data/UserFileRepositoryService.java
+++ b/src/main/java/formflow/library/data/UserFileRepositoryService.java
@@ -1,18 +1,15 @@
 package formflow.library.data;
 
-import jakarta.transaction.Transactional;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 /**
  * Service to retrieve and store UploadedFile objects in the database.
  */
 @Service
-@Transactional
 @Slf4j
 public class UserFileRepositoryService {
 

--- a/src/test/java/formflow/library/repository/SubmissionRepositoryServiceTest.java
+++ b/src/test/java/formflow/library/repository/SubmissionRepositoryServiceTest.java
@@ -206,7 +206,6 @@ class SubmissionRepositoryServiceTest {
   }
 
   private Submission saveAndReload(Submission submission) {
-    Submission savedSubmission = submissionRepositoryService.save(submission);
-    return submissionRepositoryService.findById(savedSubmission.getId()).orElseThrow();
+    return submissionRepositoryService.save(submission);
   }
 }

--- a/src/test/java/formflow/library/repository/UserFileRepositoryServiceTest.java
+++ b/src/test/java/formflow/library/repository/UserFileRepositoryServiceTest.java
@@ -9,7 +9,6 @@ import formflow.library.data.UserFileRepositoryService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,7 @@ import org.springframework.util.MimeTypeUtils;
 
 @ActiveProfiles("test")
 @SpringBootTest(properties = {"form-flow.path=flows-config/test-flow.yaml"})
-public class UserFileRepositoryServiceTests {
+public class UserFileRepositoryServiceTest {
 
   @Autowired
   private UserFileRepositoryService userFileRepositoryService;
@@ -78,7 +77,6 @@ public class UserFileRepositoryServiceTests {
   }
 
   private UserFile saveAndReload(UserFile testFile) {
-    UserFile savedFile = userFileRepositoryService.save(testFile);
-    return userFileRepositoryService.findById(savedFile.getFileId()).orElseThrow();
+    return userFileRepositoryService.save(testFile);
   }
 }


### PR DESCRIPTION
It adds no benefit given the simple ways that objects are persisted in the library. It simplifies repository code - there is no need to re-read saved objects.