### PR TITLE
Fixes security error around UUID in the delete confirmation code.

### DIFF
--- a/src/main/java/formflow/library/FileController.java
+++ b/src/main/java/formflow/library/FileController.java
@@ -1,5 +1,7 @@
 package formflow.library;
 
+import static formflow.library.utils.RegexUtils.UUID_REGEX;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Files;
 import com.lowagie.text.exceptions.BadPasswordException;
@@ -17,6 +19,7 @@ import formflow.library.file.FileVirusScanner;
 import formflow.library.utils.UserFileMap;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -31,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +55,7 @@ import java.util.zip.ZipOutputStream;
 @Controller
 @EnableAutoConfiguration
 @Slf4j
+@Validated
 public class FileController extends FormFlowController {
 
   private final CloudFileRepository cloudFileRepository;
@@ -120,12 +125,12 @@ public class FileController extends FormFlowController {
 
       Submission submission = findOrCreateSubmission(httpSession, flow);
 
-      if (shouldRedirectDueToLockedSubmission(screen, submission,flow)) {
+      if (shouldRedirectDueToLockedSubmission(screen, submission, flow)) {
         log.info("The Submission for flow {} is locked. Cannot upload file.", flow);
         String message = messageSource.getMessage("upload-documents.locked-submission", null, locale);
         return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
       }
-      
+
       UUID userFileId = UUID.randomUUID();
       if (submission.getId() == null) {
         submission.setFlow(flow);
@@ -295,8 +300,8 @@ public class FileController extends FormFlowController {
    */
   @GetMapping("/file-download/{flow}/{submissionId}/{fileId}")
   public ResponseEntity<StreamingResponseBody> downloadSingleFile(
-      @PathVariable String submissionId,
-      @PathVariable String fileId,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String submissionId,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String fileId,
       @PathVariable String flow,
       HttpSession httpSession,
       HttpServletRequest request
@@ -362,7 +367,7 @@ public class FileController extends FormFlowController {
    */
   @GetMapping("/file-download/{flow}/{submissionId}")
   public ResponseEntity<StreamingResponseBody> downloadAllFiles(
-      @PathVariable String submissionId,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String submissionId,
       @PathVariable String flow,
       HttpSession httpSession,
       HttpServletRequest request

--- a/src/main/java/formflow/library/PdfController.java
+++ b/src/main/java/formflow/library/PdfController.java
@@ -1,5 +1,7 @@
 package formflow.library;
 
+import static formflow.library.utils.RegexUtils.UUID_REGEX;
+
 import formflow.library.config.FlowConfiguration;
 import formflow.library.config.FormFlowConfigurationProperties;
 import formflow.library.data.Submission;
@@ -8,6 +10,7 @@ import formflow.library.data.UserFileRepositoryService;
 import formflow.library.pdf.PdfService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.constraints.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.MessageSource;
@@ -16,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +34,7 @@ import java.util.UUID;
 @EnableAutoConfiguration
 @Slf4j
 @RequestMapping("/download")
+@Validated
 public class PdfController extends FormFlowController {
 
   private final PdfService pdfService;
@@ -45,9 +50,9 @@ public class PdfController extends FormFlowController {
   }
 
   @GetMapping("{flow}/{submissionId}")
-  ResponseEntity<?> downloadPdf(
+  public ResponseEntity<?> downloadPdf(
       @PathVariable String flow,
-      @PathVariable String submissionId,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String submissionId,
       HttpSession httpSession,
       HttpServletRequest request,
       Locale locale

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -88,6 +88,7 @@ public class ScreenController extends FormFlowController {
     this.actionManager = actionManager;
     this.fileValidationService = fileValidationService;
     log.info("Screen Controller Created!");
+
   }
 
   /**

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -1,6 +1,7 @@
 package formflow.library;
 
 import static formflow.library.inputs.FieldNameMarkers.UNVALIDATED_FIELD_MARKER_VALIDATE_ADDRESS;
+import static formflow.library.utils.RegexUtils.UUID_REGEX;
 
 import com.smartystreets.api.exceptions.SmartyException;
 import formflow.library.address_validation.AddressValidationService;
@@ -62,7 +63,6 @@ public class ScreenController extends FormFlowController {
 
   public static final String FLOW = "/flow";
   public static final String FLOW_SCREEN_PATH = "{flow}/{screen}";
-  private final String UUID_REGEX = "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}";
   private final ValidationService validationService;
   private final AddressValidationService addressValidationService;
   private final ConditionManager conditionManager;
@@ -104,7 +104,7 @@ public class ScreenController extends FormFlowController {
       @PathVariable String flow,
       @PathVariable String screen,
       @RequestParam(required = false) Map<String, String> query_params,
-      @RequestParam(value = "uuid", required = false) String uuid,
+      @RequestParam(value = "uuid", required = false) @Pattern(regexp = UUID_REGEX) String uuid,
       RedirectAttributes redirectAttributes,
       HttpSession httpSession,
       HttpServletRequest request,
@@ -304,7 +304,7 @@ public class ScreenController extends FormFlowController {
   ModelAndView getSubflowScreen(
       @PathVariable String flow,
       @PathVariable String screen,
-      @PathVariable String uuid,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String uuid,
       HttpSession httpSession,
       HttpServletRequest request,
       RedirectAttributes redirectAttributes,
@@ -360,7 +360,7 @@ public class ScreenController extends FormFlowController {
       @RequestParam(required = false) MultiValueMap<String, String> formData,
       @PathVariable String flow,
       @PathVariable String screen,
-      @PathVariable String uuid,
+      @PathVariable @Pattern(regexp = "(" + UUID_REGEX + ")|(?i)(new)") String uuid,
       HttpSession httpSession,
       HttpServletRequest request,
       RedirectAttributes redirectAttributes,
@@ -505,7 +505,7 @@ public class ScreenController extends FormFlowController {
   ModelAndView deleteSubflowIteration(
       @PathVariable String flow,
       @PathVariable String subflow,
-      @PathVariable String uuid,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String uuid,
       HttpSession httpSession,
       HttpServletRequest request,
       RedirectAttributes redirectAttributes,
@@ -568,7 +568,7 @@ public class ScreenController extends FormFlowController {
       @PathVariable String screen,
       HttpSession httpSession,
       HttpServletRequest request,
-      @RequestParam(required = false) String uuid
+      @RequestParam(required = false) @Pattern(regexp = UUID_REGEX) String uuid
   ) {
     log.info("GET navigation (url: {}): flow: {}, screen: {}", request.getRequestURI().toLowerCase(), flow, screen);
     log.info(

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -19,6 +19,7 @@ import formflow.library.data.UserFileRepositoryService;
 import formflow.library.file.FileValidationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.constraints.Pattern;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,10 +57,12 @@ import org.springframework.web.servlet.view.RedirectView;
 @EnableAutoConfiguration
 @Slf4j
 @RequestMapping(ScreenController.FLOW)
+@Validated
 public class ScreenController extends FormFlowController {
 
   public static final String FLOW = "/flow";
   public static final String FLOW_SCREEN_PATH = "{flow}/{screen}";
+  private final String UUID_REGEX = "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}";
   private final ValidationService validationService;
   private final AddressValidationService addressValidationService;
   private final ConditionManager conditionManager;
@@ -395,7 +399,7 @@ public class ScreenController extends FormFlowController {
   ModelAndView deleteConfirmation(
       @PathVariable String flow,
       @PathVariable String subflow,
-      @PathVariable String uuid,
+      @PathVariable @Pattern(regexp = UUID_REGEX) String uuid,
       HttpSession httpSession,
       HttpServletRequest request,
       RedirectAttributes redirectAttributes,

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -423,7 +423,7 @@ public class ScreenController extends FormFlowController {
       entryToDelete.ifPresent(entry -> httpSession.setAttribute("entryToDelete", entry));
     }
 
-    return new ModelAndView(new RedirectView(String.format("/flow/%s/" + deleteConfirmationScreen + "?uuid=" + uuid, flow)));
+    return new ModelAndView(new RedirectView(String.format("/flow/%s/%s?uuid=%s", flow, deleteConfirmationScreen, uuid)));
   }
 
   /**

--- a/src/main/java/formflow/library/utils/RegexUtils.java
+++ b/src/main/java/formflow/library/utils/RegexUtils.java
@@ -15,4 +15,10 @@ public class RegexUtils {
    * regex is from Shiba.</a>
    */
   public static final String EMAIL_REGEX = "[a-zA-Z0-9!#$%&'*+=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?";
+
+
+  /**
+   * Regular expression for use in validating a version 4 UUID.
+   */
+  public static final String UUID_REGEX = "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}";
 }

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -64,12 +64,12 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       "POST, /flow/{flow}/{screen}, testFlow, screenThatDoesNotExist",
       "POST, /flow/{flow}/{screen}/submit, flowThatDoesNotExist, screen",
       "POST, /flow/{flow}/{screen}/submit, testFlow, screenThatDoesNotExist",
-      "GET, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, flowThatDoesNotExist, screen",
-      "GET, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, testFlow, screenThatDoesNotExist",
-      "POST, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, flowThatDoesNotExist, screen",
-      "POST, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, testFlow, screenThatDoesNotExist",
+      "GET, /flow/{flow}/{screen}/b9b5a3fd-cb16-47dd-b047-6295a974821a, flowThatDoesNotExist, screen",
+      "GET, /flow/{flow}/{screen}/b9b5a3fd-cb16-47dd-b047-6295a974821a, testFlow, screenThatDoesNotExist",
+      "POST, /flow/{flow}/{screen}/b9b5a3fd-cb16-47dd-b047-6295a974821a, flowThatDoesNotExist, screen",
+      "POST, /flow/{flow}/{screen}/B9B5A3FD-CB16-47DD-B047-6295A974821A, testFlow, screenThatDoesNotExist",
       "GET, /flow/{flow}/{subflowName}/117fdfa1-e914-4b3a-a040-a6109a1ea6f8/deleteConfirmation, flowThatDoesNotExist, testSubflow",
-      "POST, /flow/{flow}/{subflowName}/thisIsAUUIDForASubflow/delete, flowThatDoesNotExist, testSubflow",
+      "POST, /flow/{flow}/{subflowName}/b9b5a3fd-cb16-47dd-b047-6295a974821a/delete, flowThatDoesNotExist, testSubflow",
       "GET, /flow/{flow}/{screen}/navigation, flowThatDoesNotExist, screen",
       "GET, /flow/{flow}/{screen}/navigation, testFlow, screenThatDoesNotExist"
   })
@@ -107,11 +107,11 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
     public void modelIncludesCurrentSubflowItem() throws Exception {
       when(submissionRepositoryService.findById(submission.getId())).thenReturn(Optional.of(submission));
       HashMap<String, String> subflowItem = new HashMap<>();
-      subflowItem.put("uuid", "aaa-bbb-ccc");
+      subflowItem.put("uuid", "b9b5a3fd-cb16-47dd-b047-6295a974821a");
       subflowItem.put("firstNameSubflow", "foo bar baz");
 
       submission.setInputData(Map.of("testSubflow", List.of(subflowItem)));
-      getPageExpectingSuccess("subflowAddItem/aaa-bbb-ccc");
+      getPageExpectingSuccess("subflowAddItem/b9b5a3fd-cb16-47dd-b047-6295a974821a");
     }
 
     @Test

--- a/src/test/java/formflow/library/controllers/ScreenControllerTest.java
+++ b/src/test/java/formflow/library/controllers/ScreenControllerTest.java
@@ -2,6 +2,7 @@ package formflow.library.controllers;
 
 import static formflow.library.FormFlowController.SUBMISSION_MAP_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,6 +20,7 @@ import formflow.library.address_validation.ValidatedAddress;
 import formflow.library.data.Submission;
 import formflow.library.utilities.AbstractMockMvcTest;
 import formflow.library.utilities.FormScreen;
+import jakarta.servlet.ServletException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +68,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       "GET, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, testFlow, screenThatDoesNotExist",
       "POST, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, flowThatDoesNotExist, screen",
       "POST, /flow/{flow}/{screen}/thisIsAUUIDForASubflow, testFlow, screenThatDoesNotExist",
-      "GET, /flow/{flow}/{subflowName}/thisIsAUUIDForASubflow/deleteConfirmation, flowThatDoesNotExist, testSubflow",
+      "GET, /flow/{flow}/{subflowName}/117fdfa1-e914-4b3a-a040-a6109a1ea6f8/deleteConfirmation, flowThatDoesNotExist, testSubflow",
       "POST, /flow/{flow}/{subflowName}/thisIsAUUIDForASubflow/delete, flowThatDoesNotExist, testSubflow",
       "GET, /flow/{flow}/{screen}/navigation, flowThatDoesNotExist, screen",
       "GET, /flow/{flow}/{screen}/navigation, testFlow, screenThatDoesNotExist"
@@ -77,6 +79,13 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       case "GET" -> mockMvc.perform(get(path, flow, screen)).andExpect(status().isNotFound());
       case "POST" -> mockMvc.perform(post(path, flow, screen)).andExpect(status().isNotFound());
     }
+  }
+
+  @Test()
+  void endpointShouldNotAcceptInvalidUuid() throws Exception {
+    String badPath = "/flow/{flow}/{subflowName}/thisIsAUUIDForASubflow/deleteConfirmation";
+
+    assertThrows(ServletException.class, () -> mockMvc.perform(get(badPath, "testFlow", "testSubflow")));
   }
 
   @Nested
@@ -216,7 +225,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
           .get("subflowWithAGetAndThenAPost");
       assertThat((Boolean) iterationsAfterSecondPost.get(0).get("iterationIsComplete")).isTrue();
     }
-    
+
     @Test
     public void shouldHandleGoingFromANonSubflowPostScreenIntoASubflow() throws Exception {
       setFlowInfoInSession(session, "testSubflowLogic", submission.getId());
@@ -228,7 +237,7 @@ public class ScreenControllerTest extends AbstractMockMvcTest {
       );
       String nextScreenUrl = "/flow/testSubflowLogic/testEntryScreen/navigation";
       result.andExpect(redirectedUrl(nextScreenUrl));
-      
+
       while (Objects.requireNonNull(nextScreenUrl).contains("/navigation")) {
         // follow redirects
         nextScreenUrl = mockMvc.perform(get(nextScreenUrl).session(session))

--- a/src/test/java/formflow/library/framework/AfterSaveActionTest.java
+++ b/src/test/java/formflow/library/framework/AfterSaveActionTest.java
@@ -85,11 +85,11 @@ public class AfterSaveActionTest extends AbstractMockMvcTest {
     String expectedRecipient = "test@example.com";
     String expectedBody = "This is a test email";
 
-    ResultActions test = postWithoutData("subflowIterationStart/new");
+    ResultActions test = postWithoutData("subflowIterationStart/NEW");
     String url = test.andExpect(status().is3xxRedirection())
-            .andReturn()
-            .getResponse()
-            .getRedirectedUrl();
+        .andReturn()
+        .getResponse()
+        .getRedirectedUrl();
     assertThat(url).isNotNull();
     assertThat(url.contains("next"));
 

--- a/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
+++ b/src/test/java/formflow/library/utilities/AbstractMockMvcTest.java
@@ -84,6 +84,19 @@ public abstract class AbstractMockMvcTest {
         .build();
   }
 
+  /**
+   * This sets flow information in the session. The flowInfo parameter is a list of matched pairs of flow -> submission id.  A
+   * call to this method might look like this:<br>
+   * <code>
+   * &nbsp;&nbsp;UUID flowAUUID = UUID.fromString("0f045de7-0b7a-4799-ba62-9958755dc78c");<br>&nbsp;&nbsp;UUID flowBUUID =
+   * UUID.fromString("923e25b7-c60b-49e9-8686-210a41bd4a6d");<br>&nbsp;&nbsp;UUID flowCUUID =
+   * UUID.fromString("af543def-1fc4-40c6-9284-4277f598ee8b");<br>&nbsp;&nbsp;setFlowInfoSession(session, "flowA", flowAUUID,
+   * "flowB", flowBUUID, "flowC", flowCUUID);
+   * </code>
+   *
+   * @param mockHttpSession the session to set the data in
+   * @param flowInfo        objects that are pairs of flow->submission id. There can be many, as long as they are paired up.
+   */
   protected void setFlowInfoInSession(MockHttpSession mockHttpSession, Object... flowInfo) {
     if (flowInfo.length % 2 != 0) {
       throw new IllegalArgumentException("Arguments should be paired flowName -> submission id (UUID).");
@@ -137,10 +150,10 @@ public abstract class AbstractMockMvcTest {
   protected ResultActions postToUrlExpectingSuccess(String postUrl, String redirectUrl,
       Map<String, List<String>> params) throws Exception {
     return mockMvc.perform(post(postUrl)
-            .with(csrf())
-            .session(session)
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-            .params(new LinkedMultiValueMap<>(params))
+        .with(csrf())
+        .session(session)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+        .params(new LinkedMultiValueMap<>(params))
     ).andExpect(redirectedUrl(redirectUrl));
   }
 
@@ -148,10 +161,10 @@ public abstract class AbstractMockMvcTest {
   protected ResultActions postToUrlExpectingSuccessRedirectPattern(String postUrl, String redirectUrlPattern,
       Map<String, List<String>> params) throws Exception {
     return mockMvc.perform(post(postUrl)
-            .with(csrf())
-            .session(session)
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-            .params(new LinkedMultiValueMap<>(params))
+        .with(csrf())
+        .session(session)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+        .params(new LinkedMultiValueMap<>(params))
     ).andExpect(redirectedUrlPattern(redirectUrlPattern));
   }
 
@@ -298,9 +311,9 @@ public abstract class AbstractMockMvcTest {
     while (Objects.requireNonNull(nextPage).contains("/navigation")) {
       // follow redirects
       nextPage = mockMvc.perform(get(nextPage).session(session))
-              .andExpect(status().is3xxRedirection()).andReturn()
-              .getResponse()
-              .getRedirectedUrl();
+          .andExpect(status().is3xxRedirection()).andReturn()
+          .getResponse()
+          .getRedirectedUrl();
     }
     return new FormScreen(mockMvc.perform(get(nextPage)));
   }


### PR DESCRIPTION
In theory this fixes the error seen here: https://github.com/codeforamerica/form-flow/security/code-scanning/1

Although, now I'm wondering if this would be fixed by simply making all the items either in the String.format() or concatenations, but not both. 