### PR TITLE
Fix error where any page with the word "submit" in its name would cause the submission to submit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,12 +182,12 @@ publishing {
                         name = 'Bethany Seeger'
                         email = 'bseeger@codeforamerica.org'
                     }
-                     developer {
+                    developer {
                         id = 'vrajmohan'
                         name = 'Vraj Mohan'
                         email = 'vraj@codeforamerica.org'
                     }
-                     developer {
+                    developer {
                         id = 'marthapidcock'
                         name = 'Martha Pidcock'
                         email = 'mpidcock@codeforamerica.org'
@@ -225,6 +225,6 @@ nexusPublishing {
     }
 }
 
- javadoc {
-     options.addStringOption('Xmaxwarns', '1000')
- }
+javadoc {
+    options.addStringOption('Xmaxwarns', '1000')
+}

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -260,6 +260,14 @@ public class ScreenController extends FormFlowController {
     // Address validation
     handleAddressValidation(submission, formSubmission);
 
+    // if there's already a session
+    if (submission.getId() != null) {
+      submission.mergeFormDataWithSubmissionData(formSubmission);
+    } else {
+      submission.setFlow(flow);
+      submission.setInputData(formSubmission.getFormData());
+    }
+
     // handle marking the record as submitted, if necessary
     if (submitSubmission) {
       log.info(
@@ -269,14 +277,6 @@ public class ScreenController extends FormFlowController {
           )
       );
       submission.setSubmittedAt(OffsetDateTime.now());
-    }
-
-    // if there's already a session
-    if (submission.getId() != null) {
-      submission.mergeFormDataWithSubmissionData(formSubmission);
-    } else {
-      submission.setFlow(flow);
-      submission.setInputData(formSubmission.getFormData());
     }
 
     actionManager.handleBeforeSaveAction(currentScreen, submission);
@@ -403,7 +403,8 @@ public class ScreenController extends FormFlowController {
         submission.getInputData().put(subflowName, new ArrayList<Map<String, Object>>());
       }
       if (isNewIteration) {
-        ArrayList<Map<String, Object>> subflow = (ArrayList<Map<String, Object>>) submission.getInputData().get(subflowName);
+        ArrayList<Map<String, Object>> subflow = (ArrayList<Map<String, Object>>) submission.getInputData()
+            .get(subflowName);
         formSubmission.getFormData().put("uuid", iterationUuid);
         formSubmission.getFormData().putIfAbsent(Submission.ITERATION_IS_COMPLETE_KEY, false);
         subflow.add(formSubmission.getFormData());
@@ -714,7 +715,8 @@ public class ScreenController extends FormFlowController {
     // Merge form data that was submitted, with already existing inputData
     // This helps in the case of errors, so all the current data is on the page
     if (httpSession.getAttribute("formDataSubmission") != null) {
-      FormSubmission formSubmission = new FormSubmission((Map<String, Object>) httpSession.getAttribute("formDataSubmission"));
+      FormSubmission formSubmission = new FormSubmission(
+          (Map<String, Object>) httpSession.getAttribute("formDataSubmission"));
       if (subflowName != null && uuid != null && !uuid.isBlank()) {
         // there is existing data to merge with
         submission.mergeFormDataWithSubflowIterationData(subflowName, submission.getSubflowEntryByUuid(subflowName, uuid),

--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -197,7 +197,7 @@ public class ScreenController extends FormFlowController {
     handleAddressValidation(submission, formSubmission);
 
     // handle submit actions, if requested
-    if (request.getRequestURI().toLowerCase().contains("submit")) {
+    if (request.getRequestURI().toLowerCase().endsWith("/submit")) {
       log.info(
           String.format(
               "Marking the application (%s) as submitted",

--- a/src/test/resources/templates/testFlow/pageWithCustomSubmitButton.html
+++ b/src/test/resources/templates/testFlow/pageWithCustomSubmitButton.html
@@ -10,7 +10,7 @@
         <th:block
             th:replace="~{fragments/cardHeader :: cardHeader(header='Page with optional validation')}"/>
         <th:block
-            th:replace="~{fragments/form :: form(action=${formAction + '/submit'}, content=~{::formContent})}">
+            th:replace="~{fragments/form :: form(action=${formAction} + '/submit', content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(

--- a/src/test/resources/templates/testFlow/pageWithCustomSubmitButton.html
+++ b/src/test/resources/templates/testFlow/pageWithCustomSubmitButton.html
@@ -10,7 +10,7 @@
         <th:block
             th:replace="~{fragments/cardHeader :: cardHeader(header='Page with optional validation')}"/>
         <th:block
-            th:replace="~{fragments/form :: form(action=${formAction} + '/submit', content=~{::formContent})}">
+            th:replace="~{fragments/form :: form(action=${formAction + '/submit'}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(


### PR DESCRIPTION
I just discovered that if a page has the word "submit" in the name of the page, it will cause the submission to get submitted. 

Thankfully the only examples of where this happens in state projects is where we do want the data marked as submitted. 

Tests are updated as well.  