### PR TITLE
Pull the submission id from session correctly in the MDC Filter Log

### DIFF
--- a/src/main/java/formflow/library/filters/MDCInsertionFilter.java
+++ b/src/main/java/formflow/library/filters/MDCInsertionFilter.java
@@ -1,16 +1,20 @@
 package formflow.library.filters;
 
+import formflow.library.FormFlowController;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Map;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.UUID;
+import org.springframework.util.AntPathMatcher;
 
 /**
  * Inserts useful attributes into the Mapped Diagnostic Context (MDC) for logging by clients.
@@ -18,31 +22,45 @@ import java.util.UUID;
 @Component
 public class MDCInsertionFilter implements Filter {
 
-  @Override
-  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
-      FilterChain filterChain) throws ServletException, IOException {
-    HttpServletRequest request = (HttpServletRequest) servletRequest;
+    public static final String PATH_FORMAT = "/flow/{flow}/{screen}";
 
-    var session = request.getSession(false);
-    var sessionId = session == null ? null : session.getId();
-    UUID submissionId = session == null ? null : (UUID) session.getAttribute("id");
+    @Override
+    public void doFilter(
+        ServletRequest servletRequest,
+        ServletResponse servletResponse,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
 
-    MDC.put("sessionId", sessionId);
-    MDC.put("submissionId", String.valueOf(submissionId));
-    MDC.put("xForwardedFor", request.getHeader("X-Forwarded-For"));
-    MDC.put("method", request.getMethod());
-    MDC.put("request", request.getRequestURI());
+        HttpSession session = request.getSession(false);
+        String sessionId = session == null ? null : session.getId();
+        UUID submissionId = null;
 
-    filterChain.doFilter(servletRequest, servletResponse);
+        try {
+            Map<String, String> parsedUrl = new AntPathMatcher().extractUriTemplateVariables(PATH_FORMAT,
+                request.getRequestURI());
+            submissionId = FormFlowController.getSubmissionIdForFlow(session, parsedUrl.get("flow"));
+        } catch (Exception e) {
+            // We could get an error if there is no session or if the URL didn't match the
+            // expected pattern '/flow/{flow}/{screen}' and that's okay. Just ignore this and log
+            // what data we have.
+        }
 
-    removeMDCAttributes();
-  }
+        MDC.put("sessionId", sessionId);
+        MDC.put("submissionId", String.valueOf(submissionId));
+        MDC.put("xForwardedFor", request.getHeader("X-Forwarded-For"));
+        MDC.put("method", request.getMethod());
+        MDC.put("request", request.getRequestURI());
 
-  private static void removeMDCAttributes() {
-    MDC.remove("sessionId");
-    MDC.remove("submissionId");
-    MDC.remove("xForwardedFor");
-    MDC.remove("method");
-    MDC.remove("request");
-  }
+        filterChain.doFilter(servletRequest, servletResponse);
+        removeMDCAttributes();
+    }
+
+    private static void removeMDCAttributes() {
+        MDC.remove("sessionId");
+        MDC.remove("submissionId");
+        MDC.remove("xForwardedFor");
+        MDC.remove("method");
+        MDC.remove("request");
+    }
 }


### PR DESCRIPTION
This will fix how the submission id is pull from the session in the MDC Insertion Filter Code.  The code needs to pull it from a session map, or better yet, use the logic in the FormFlowController parent class to get the submission id.  This code now does this.

This also changes the indent of this code to 4 spaces. 