### PR TITLE
Fix security error: externally-controlled format string

### DIFF
--- a/src/main/java/formflow/library/ScreenController.java
+++ b/src/main/java/formflow/library/ScreenController.java
@@ -484,7 +484,7 @@ public class ScreenController extends FormFlowController {
       entryToDelete.ifPresent(entry -> httpSession.setAttribute("entryToDelete", entry));
     }
 
-    return new ModelAndView(new RedirectView(String.format("/flow/%s/" + deleteConfirmationScreen + "?uuid=" + uuid, flow)));
+    return new ModelAndView(new RedirectView(String.format("/flow/%s/%s?uuid=%s", flow, deleteConfirmationScreen, uuid)));
   }
 
   /**


### PR DESCRIPTION
This simply reformats the way a string was getting created, as the old way was triggering a security alert.