### PR TITLE
Update fragments

### DIFF
--- a/src/main/java/formflow/library/inputs/InputOption.java
+++ b/src/main/java/formflow/library/inputs/InputOption.java
@@ -1,0 +1,10 @@
+package formflow.library.inputs;
+
+public interface InputOption {
+  String getValue();
+
+  String getLabel();
+
+  String getHelpText();
+
+}

--- a/src/main/resources/templates/fragments/inputs/checkboxFieldset.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxFieldset.html
@@ -4,6 +4,8 @@
       hasHelpText=${!#strings.isEmpty(fieldsetHelpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
+      hasOptions=${options != null},
+      hasContent=${!hasOptions},
       hasError=${
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
@@ -11,7 +13,7 @@
     th:assert="
       ${!#strings.isEmpty(inputName)},
       ${hasLabel || hasAriaLabel},
-      ${content != null}">
+      ${hasContent || hasOptions}">
   <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
     <fieldset th:attr="
       aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
@@ -27,7 +29,18 @@
            th:text="${fieldsetHelpText}"></p>
       </legend>
       <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${inputName} + '[]'" value="">
-      <th:block th:replace="${content}"/>
+      <th:block th:if="${hasContent}">
+        <th:block th:replace="${content}"/>
+      </th:block>
+      <th:block th:if="${hasOptions}">
+        <th:block th:each="option : ${options}">
+          <th:block th:replace="~{fragments/inputs/checkboxInSet ::
+            checkboxInSet(inputName=${inputName},
+              value=${option.getValue()},
+              label=${#strings.isEmpty(option.getLabel()) ? null : #messages.msg(option.getLabel())},
+              checkboxHelpText=${#strings.isEmpty(option.getHelpText()) ? null : #messages.msg(option.getHelpText())})}"/>
+        </th:block>
+      </th:block>
       <th:block
           th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
     </fieldset>

--- a/src/main/resources/templates/fragments/inputs/radioFieldset.html
+++ b/src/main/resources/templates/fragments/inputs/radioFieldset.html
@@ -4,6 +4,8 @@
       hasHelpText=${!#strings.isEmpty(fieldsetHelpText)},
       hasLabel=${!#strings.isEmpty(label)},
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
+      hasOptions=${options != null},
+      hasContent=${!hasOptions},
       hasError=${
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
@@ -11,7 +13,7 @@
     th:assert="
       ${!#strings.isEmpty(inputName)},
       ${hasLabel || hasAriaLabel},
-      ${content != null}">
+      ${hasContent || hasOptions}">
   <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
     <fieldset th:attr="
       aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
@@ -26,7 +28,18 @@
            th:text="${fieldsetHelpText}"></p>
       </legend>
       <input type="hidden" th:id="${inputName} + 'Hidden'" th:name="${inputName}" value="">
-      <th:block th:replace="${content}"/>
+      <th:block th:if="${hasContent}">
+        <th:block th:replace="${content}"/>
+      </th:block>
+      <th:block th:if="${hasOptions}">
+        <th:block th:each="option : ${options}">
+          <th:block th:replace="~{fragments/inputs/radio ::
+            radio(inputName=${inputName},
+              value=${option.getValue()},
+              label=${#strings.isEmpty(option.getLabel()) ? null : #messages.msg(option.getLabel())},
+              radioHelpText=${#strings.isEmpty(option.getHelpText()) ? null : #messages.msg(option.getHelpText())})}"/>
+        </th:block>
+      </th:block>
     </fieldset>
     <th:block
         th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>

--- a/src/test/java/formflow/library/framework/InputsTest.java
+++ b/src/test/java/formflow/library/framework/InputsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import formflow.library.address_validation.AddressValidationService;
 import formflow.library.address_validation.ValidatedAddress;
+import formflow.library.inputs.TestOption;
 import formflow.library.utilities.AbstractMockMvcTest;
 import formflow.library.utilities.FormScreen;
 import java.util.HashMap;
@@ -39,8 +40,10 @@ public class InputsTest extends AbstractMockMvcTest {
     String numberInput = "123";
     // First "" value is from hidden input that a screen would submit
     List<String> checkboxSet = List.of("", "Checkbox-A", "Checkbox-B");
+    List<String> checkboxEnumSet = List.of("MANGO", "OTHER");
     List<String> checkboxInput = List.of("", "checkbox-value");
     String radioInput = "Radio B";
+    String radioInputEnum = TestOption.MANGO.getValue();
     String selectInput = "Select B";
     String moneyInput = "100";
     String phoneInput = "(555) 555-1234";
@@ -57,9 +60,11 @@ public class InputsTest extends AbstractMockMvcTest {
             Map.entry("numberInput", List.of(numberInput)),
             // CheckboxSet's need to have the [] in their name for POST actions
             Map.entry("checkboxSet[]", checkboxSet),
+            Map.entry("checkboxEnumSet[]", checkboxEnumSet),
             // Checkboxes need to have the [] in their name for POST actions
             Map.entry("checkboxInput[]", checkboxInput),
             Map.entry("radioInput", List.of(radioInput)),
+            Map.entry("radioInputEnum", List.of(radioInputEnum)),
             Map.entry("selectInput", List.of(selectInput)),
             Map.entry("moneyInput", List.of(moneyInput)),
             Map.entry("phoneInput", List.of(phoneInput)),
@@ -81,8 +86,10 @@ public class InputsTest extends AbstractMockMvcTest {
     assertThat(inputsScreen.getInputValue("dateYear")).isEqualTo(dateYear);
     assertThat(inputsScreen.getInputValue("numberInput")).isEqualTo(numberInput);
     assertThat(inputsScreen.getCheckboxSetValues("checkboxSet")).isEqualTo(removedHiddenCheckboxSet);
+    assertThat(inputsScreen.getCheckboxSetValues("checkboxEnumSet")).isEqualTo(checkboxEnumSet);
     assertThat(inputsScreen.getCheckboxSetValues("checkboxInput")).isEqualTo(removedHiddenCheckboxInput);
     assertThat(inputsScreen.getRadioValue("radioInput")).isEqualTo(radioInput);
+    assertThat(inputsScreen.getRadioValue("radioInputEnum")).isEqualTo(radioInputEnum);
     assertThat(inputsScreen.getSelectValue("selectInput")).isEqualTo(selectInput);
     assertThat(inputsScreen.getInputValue("moneyInput")).isEqualTo(moneyInput);
     assertThat(inputsScreen.getInputValue("phoneInput")).isEqualTo(phoneInput);

--- a/src/test/java/formflow/library/inputs/TestFlow.java
+++ b/src/test/java/formflow/library/inputs/TestFlow.java
@@ -36,8 +36,10 @@ public class TestFlow extends FlowInputs {
 
   String numberInput;
   ArrayList<String> checkboxSet;
+  ArrayList<String> checkboxEnumSet;
   ArrayList<String> checkboxInput;
   String radioInput;
+  String radioInputEnum;
   String selectInput;
   String moneyInput;
   String phoneInput;

--- a/src/test/java/formflow/library/inputs/TestOption.java
+++ b/src/test/java/formflow/library/inputs/TestOption.java
@@ -1,0 +1,30 @@
+package formflow.library.inputs;
+
+public enum TestOption implements InputOption {
+  MANGO("input-options.fruit.mango", "input-options.fruit.mango-desc"),
+  PAPAYA("input-options.fruit.papaya", "input-options.fruit.papaya-desc"),
+  GUAVA("input-options.fruit.guava", null),
+  OTHER("general.other", null);
+
+  public String getLabel() {
+    return label;
+  }
+
+  private final String label;
+
+  public String getHelpText() {
+    return helpText;
+  }
+
+  private final String helpText;
+
+  TestOption(String label, String helpText) {
+    this.label = label;
+    this.helpText = helpText;
+  }
+
+  @Override
+  public String getValue() {
+    return this.name();
+  }
+}

--- a/src/test/resources/templates/testFlow/inputs.html
+++ b/src/test/resources/templates/testFlow/inputs.html
@@ -38,6 +38,13 @@
                       th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='checkboxSet', value='Checkbox-B', label='Checkbox B')}"/>
                 </th:block>
               </th:block>
+              <th:block th:with="checkboxOptions=${T(formflow.library.inputs.TestOption).values()}">
+                <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
+                          checkboxFieldset(inputName='checkboxEnumSet',
+                          label='checkboxEnumSet',
+                          options=${checkboxOptions})}">
+                </th:block>
+              </th:block>
               <th:block
                   th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='checkboxInput', value='checkbox-value', label='Single checkbox')}"/>
               <th:block th:replace="~{fragments/inputs/radioFieldset ::
@@ -51,6 +58,13 @@
                       th:replace="~{fragments/inputs/radio :: radio(inputName='radioInput',value='Radio B', label='Radio B')}"/>
                   <th:block
                       th:replace="~{fragments/inputs/radio :: radio(inputName='radioInput',value='Radio C', label='Radio C', radioHelpText='Radio C')}"/>
+                </th:block>
+              </th:block>
+              <th:block th:with="radioOptions=${T(formflow.library.inputs.TestOption).values()}">
+                <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                          radioFieldset(inputName='radioInputEnum',
+                          label='radioInputEnum',
+                          options=${radioOptions})}">
                 </th:block>
               </th:block>
               <th:block


### PR DESCRIPTION
#### Description of change ✍️

Updated the checkbox and radio fieldset fragments to be able to take a collection of options. 

The `options` param are values from classes that implement `InputOption`. They must have a value and label/helpText are optional. This is to simplify rendering for static checkboxes and have a more centralized way of referencing these values in html rendering and PDF generation.
*Backwards compatible.


#### Priority 🥇
Medium - we can override locally for now

#### Effect on other applications using FFB 🌊

No breaking changes - this will be backwards compatible

#### Testing
There's a unit test showing how to use this new param. Here's an example as well (GenderOptions will have to be implements)

```html
<th:block th:with="genderOptions=${T(org.ilgcc.app.utils.GenderOption).values()},
  <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
    checkboxFieldset(inputName='childGender',
      label=#{children-ccap-info.gender-question},
      options=${genderOptions})}"/>
```


#### ✅ Checklist before requesting a review

- [ ] Does the new code follow [our preferred coding
  style](/intellij-settings/PlatformFlavoredGoogleStyle.xml)?
- [ ] Does the code include javadocs, where necessary?
- [ ] Have tests for this feature been added / updated?
- [ ] Has the readme been updated?
