### PR TITLE
Addressing a11y issue

### DIFF
--- a/src/main/resources/templates/fragments/inputError.html
+++ b/src/main/resources/templates/fragments/inputError.html
@@ -1,6 +1,6 @@
 <p th:if="${null != errorMessages}" th:fragment="validationError(inputName)" class="text--error"
    th:assert="${!#strings.isEmpty(inputName)}"
-   th:aria-label="#{error.error}"
+   th:title="#{error.error}"
    th:id="${inputName} + '-error-p'">
   <th:block th:each="error, iter: ${errorMessages.get(inputName)}">
     <i class="icon-warning" th:id="${inputName + '-error-icon'} + ${iter.index + 1}"></i>


### PR DESCRIPTION
#### Description of change ✍️
Addressing this axe dev tool violation. Note that this is one possible resolution to this issue. Also, not sure why this error happens for some fields and not others.

<img width="571" alt="Screen Shot 2024-01-08 at 4 28 34 PM" src="https://github.com/codeforamerica/form-flow/assets/72890349/c9741284-2806-440b-8d0e-ce40286b81fe">

See [slack thread](https://cfastaff.slack.com/archives/C064F8ZUPT9/p1704815597932779)

#### Priority 🥇
Medium - Nice to have, but can be overwritten in SNE apps

#### Effect on other applications using FFB 🌊
Shouldn't break other apps unless they do something custom around this attr specifically - not expected though.

#### Testing
Running axe-devtools in chrome browser

#### ✅ Checklist before requesting a review

- [x] Does the new code follow [our preferred coding
  style](/intellij-settings/PlatformFlavoredGoogleStyle.xml)?
- [ ] Does the code include javadocs, where necessary?
- [ ] Have tests for this feature been added / updated?
- [ ] Has the readme been updated?
