### PR TITLE
Change go back < to icon and add nav

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/css/libraryStyles.css
@@ -731,3 +731,13 @@ body,
     display: block;
   }
 }
+
+.underline {
+  text-decoration: underline;
+}
+
+.go-back-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/main/resources/messages-form-flow.properties
+++ b/src/main/resources/messages-form-flow.properties
@@ -8,6 +8,7 @@ general.year-format=yyyy
 general.edit=edit
 general.delete=delete
 general.go-back=Go Back
+general.go-back-region=Secondary
 general.inputs.yes=Yes
 general.inputs.no=No
 general.inputs.continue=Continue

--- a/src/main/resources/messages-form-flow_es.properties
+++ b/src/main/resources/messages-form-flow_es.properties
@@ -8,6 +8,7 @@ general.year-format=aaaa
 general.edit=editar
 general.delete=borrar
 general.go-back=Regresa
+general.go-back-region=Secundario
 general.inputs.yes=Sí
 general.inputs.no=No
 general.inputs.continue=Continuar

--- a/src/main/resources/templates/fragments/goBack.html
+++ b/src/main/resources/templates/fragments/goBack.html
@@ -1,7 +1,7 @@
-<div th:fragment="goBackLink" class="form-width">
-  <a th:text="'&lt; ' + #{general.go-back}"
-     id="back-link"
-     class="toolbar__left"
-     href="#"
-     onclick="window.history.back(); return false;"></a>
-</div>
+<nav th:fragment="goBackLink" class="form-width" th:aria-label="#{general.go-back-region}">
+  <a id="back-link" class="toolbar__left go-back-link" href="#"
+     onclick="window.history.back(); return false;">
+    <i class="icon-navigate_before" aria-hidden="true"></i>
+    <span class="underline" th:text="#{general.go-back}"></span>
+  </a>
+</nav>


### PR DESCRIPTION
#### Issue tracking number 🔗
[#187042695](https://www.pivotaltracker.com/story/show/187042695)

#### Description of change ✍️
Replace the `<` symbol with an icon that is not read by a screen reader. Then wrap the go back link inside of a `<nav>` so that the content is within a region ([best practice from deque](https://dequeuniversity.com/rules/axe/4.8/region))

- Label the nav as secondary, I left out "navigation" in the label because it is already said by the role ([MDN guidance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role#associated_wai-aria_roles_states_and_properties))

In Voice Over:

![2024-03-13 at 17 36 10@2x](https://github.com/codeforamerica/form-flow/assets/9101728/b3de5f62-bea3-4aac-9c4d-9a6f07cdf317)



#### Priority 🥇

Next formal release.

#### Effect on other applications using FFB 🌊
No breaking changes, if application are using their own go back fragment, nothing will change. If they are using the library fragment, they will automatically get this improvement.

#### Testing

- Run an application that is using form-flow (starter app, IL-GCC)
- Go to a screen in a flow, they usually have a "go back" link
- Using a screen reader, when you focus on the go back link, the icon will not be spoken

#### ✅ Checklist before requesting a review

- [x] Does the new code follow [our preferred coding
  style](/intellij-settings/PlatformFlavoredGoogleStyle.xml)? - Yes
- [x] Does the code include javadocs, where necessary? - N/A
- [x] Have tests for this feature been added / updated? - N/A
- [x] Has the readme been updated? - N/A
