### PR TITLE
Update deprecated gradle build action in github actions workflows

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
           server-id: github
           settings-path: ${{ github.workspace }}
       - name: Create jar and publish to Sonatype
-        uses: gradle/gradle-build-action@v3.4.1
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jar publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           echo "signing.gnupg.passphrase=${{ secrets.PLATFORM_ROBOT_GPG_PASSPHRASE }}" >> ~/.gradle/gradle.properties
           echo "no-tty" >> ~/.gnupg/gpg.conf >> ~/.gradle/gradle.properties
       - name: Publish package
-        uses: gradle/gradle-build-action@v3.4.1
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:


### PR DESCRIPTION
#### Description of change ✍️
Updates the gradle build step of several actions workflows where the gradle build step was deprecated. 

See: https://github.com/marketplace/actions/gradle-build-action
