### PR TITLE
Fix bouncycastle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ dependencies {
     implementation 'com.mailgun:mailgun-java:1.1.3'
     implementation 'com.google.crypto.tink:tink:1.14.0'
     implementation 'org.springframework.session:spring-session-jdbc'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
     // For M1 issue?
     //runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.97.Final:osx-aarch_64'
@@ -111,6 +110,8 @@ dependencies {
     testImplementation 'org.postgresql:postgresql'
     testImplementation 'org.projectlombok:lombok:1.18.34'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+
 }
 
 test {


### PR DESCRIPTION
Fixes an issue where a dependency was being incorrectly imported as `implementation` when it should have been `testImplementation` causing applications using the library to break. 