### PR TITLE
Remove redundant Java dependency in favor of java-library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java-library'
     id 'maven-publish'
-    id 'java'
     id 'com.adarshr.test-logger' version '4.0.0'
     id 'jacoco'
     id 'signing'
@@ -129,10 +128,6 @@ jacocoTestReport {
 java {
     withJavadocJar()
     withSourcesJar()
-}
-
-afterEvaluate {
-    components.remove(components.findByName("java"))
 }
 
 tasks.named('bootJar').configure {


### PR DESCRIPTION
- Java-library already has the java dependency as a transitive dependency
- Fixes annoying Idea error
