### PR TITLE
[CCAP-1259] There's no need to stamp a new PDF

### DIFF
--- a/src/main/java/formflow/library/file/FileConversionService.java
+++ b/src/main/java/formflow/library/file/FileConversionService.java
@@ -439,15 +439,35 @@ public class FileConversionService {
         String modifiedPDFPath =
                 Files.getNameWithoutExtension(Objects.requireNonNull(tempFile.getAbsolutePath())) + "-modified.pdf";
 
-        PdfReader reader = new PdfReader(tempFile.getAbsolutePath());
-        reader.setModificationAllowedWithoutOwnerPassword(true);
+        PdfReader reader = null;
+        Document document = null;
+        FileOutputStream outputStream = null;
+        PdfCopy copy = null;
 
-        FileOutputStream outputStream = new FileOutputStream(modifiedPDFPath);
-        PdfStamper stamper = new PdfStamper(reader, outputStream, PdfWriter.VERSION_1_7);
+        try {
+            reader = new PdfReader(tempFile.getAbsolutePath());
+            reader.setModificationAllowedWithoutOwnerPassword(true);
 
-        stamper.close();
-        reader.close();
-        outputStream.close();
+            outputStream = new FileOutputStream(modifiedPDFPath);
+            document = new Document(reader.getPageSizeWithRotation(1));
+            copy = new PdfCopy(document, outputStream);
+
+            document.open();
+            for (int i = 1; i <= reader.getNumberOfPages(); i++) {
+                copy.addPage(copy.getImportedPage(reader, i));
+            }
+
+        } finally {
+            if (document != null) {
+                document.close();
+            }
+            if (reader != null) {
+                reader.close();
+            }
+            if (outputStream != null) {
+                outputStream.close();
+            }
+        }
 
         return new File(modifiedPDFPath);
     }


### PR DESCRIPTION
#### Issue tracking number 🔗
https://codeforamerica.atlassian.net/browse/CCAP-1259

#### Description of change ✍️
We're not stamping text or annotations, so we can actually just make a copy and avoid this error. The underlying issue is that this PDF has inline values instead of indirect references-- this could happen in the future for other PDFs as well, so this is a worthwhile simple fix.

#### Priority 🥇

<!-- How quickly do you need this change to show up in the SNAPSHOT? -->
<!-- How quickly do you need this change to show up in a formal release? -->

#### Effect on other applications using FFB 🌊

<!-- Are there breaking changes in this PR? Will other projects need to update their code after this
change? If so, how? -->

#### Testing

<!-- If it's not obvious, please describe how we can test this PR. -->

#### ✅ Checklist before requesting a review

- [ ] Does the new code follow [our preferred coding
  style](/intellij-settings/PlatformFlavoredGoogleStyle.xml)?
- [ ] Does the code include javadocs, where necessary?
- [ ] Have tests for this feature been added / updated?
- [ ] Has the readme been updated?
