### PR TITLE
fix(security): set explicit persist-credentials on actions/checkout steps

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.refToRelease }}
+          persist-credentials: true
       - name: Tag Version
         env:
           VERSION: ${{inputs.version}}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,6 +24,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up JDK 21
         uses: actions/setup-java@v5.6.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.version }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v5.6.0
         with:
@@ -115,6 +116,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.PLATFORM_ROBOT_PAT }}
+          persist-credentials: true
       - name: Create new snapshot version string
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v5.6.0


### PR DESCRIPTION
## Summary
- Fixes Aikido finding: `actions/checkout` persists the `GITHUB_TOKEN` in git config by default, widening the attack surface if a later step or third-party action is compromised.
- Set `persist-credentials: false` on checkout steps that don't push (`run-tests.yml`, `publish-snapshot.yml`, `release.yml` build job).
- Set `persist-credentials: true` explicitly on the two checkout steps that do push (`pre-release.yml` tag push, `release.yml` post-release version bump push), to make the intent clear.

## Test plan
- [ ] Confirm `run-tests.yml` still runs successfully on PRs
- [ ] Confirm `publish-snapshot.yml` still publishes snapshots on merge to main
- [ ] Confirm `pre-release.yml` can still tag and push a pre-release
- [ ] Confirm `release.yml` can still release to Sonatype and push the post-release version bump to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)