### PR TITLE
fix(security): restrict language selector redirect to same-origin URLs

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js
+++ b/src/main/resources/META-INF/resources/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js
@@ -251,7 +251,7 @@ class LanguageSelector {
           if (mixpanel) {
             mixpanel.track('language-selector-click',);
           }
-          window.location.href = tgt.href;
+          this.navigateToMenuitem(tgt);
           break;
 
         case 'Esc':
@@ -301,6 +301,21 @@ class LanguageSelector {
     if (flag) {
       event.stopPropagation();
       event.preventDefault();
+    }
+  }
+
+  // Only navigate to same-origin destinations rendered by the server,
+  // guarding against javascript: URIs or cross-origin redirects.
+  navigateToMenuitem(tgt) {
+    var url;
+    try {
+      url = new URL(tgt.href, window.location.origin);
+    } catch (e) {
+      return;
+    }
+
+    if (url.origin === window.location.origin) {
+      window.location.href = url.href;
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes Aikido finding: `window.location.href = tgt.href` in `formFlowLanguageSelector.js` assigns a redirect target from a DOM property without validation, flagged as a potential DOM-based open redirect / XSS sink.
- The `href` values are currently server-rendered from the `form-flow.languages` config (not raw user input), but added defense-in-depth: a new `navigateToMenuitem` helper resolves the URL and only allows navigation when it's same-origin, rejecting `javascript:` URIs and cross-origin destinations.

## Test plan
- [ ] Open a page with the language selector, use keyboard (Space) on a language menu item, confirm it still navigates and switches language as before
- [ ] Confirm mouse/click interactions with the language selector still work